### PR TITLE
Flush printed ast

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -312,6 +312,7 @@ int main(int argc, char** argv) {
         p.tab = std::string(opts.tab_width, ' ');
         program.print(p);
         log::out << "\n";
+        log::out.stream.flush();
     }
 
     if (!success)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -306,12 +306,12 @@ int main(int argc, char** argv) {
 
     if (opts.print_ast) {
         if (log.errors > 0 || log.warns > 0)
-            log::out << "\n";
+            log::out << '\n';
         Printer p(log::out);
         p.show_implicit_casts = opts.show_implicit_casts;
         p.tab = std::string(opts.tab_width, ' ');
         program.print(p);
-        log::out << "\n";
+        log::out << '\n';
         log::out.stream.flush();
     }
 


### PR DESCRIPTION
Code that triggers assertions within artic/thorin causes the compiler to terminate. An attempt to use `--print-ast` to produce a repro for such code is likely to result in disappointment as process termination caused by the abort caused by the assertion will leave stdout unflushed and, thus, parts of the printed AST unprinted. This PR aims to fix that by flushing the output stream after printing the AST.