### PR TITLE
Fix for bug AnyDSL/thorin#134

### DIFF
--- a/src/emit.cpp
+++ b/src/emit.cpp
@@ -906,36 +906,36 @@ const thorin::Def* Emitter::builtin(const ast::FnDecl& fn_decl, thorin::Continua
         auto ret_val = call(comparator(fn_decl.loc, mono_type), tuple_from_params(cont, true));
         jump(cont->params().back(), ret_val);
     } else {
-        static const std::unordered_map<std::string, std::function<const thorin::Def* (const thorin::Continuation*)>> functions = {
-            { "fabs",     [&] (const thorin::Continuation* cont) { return world.fabs(cont->param(1)); } },
-            { "copysign", [&] (const thorin::Continuation* cont) { return world.copysign(cont->param(1), cont->param(2)); } },
-            { "signbit",  [&] (const thorin::Continuation* cont) { return signbit(cont->param(1)); } },
-            { "round",    [&] (const thorin::Continuation* cont) { return world.round(cont->param(1)); } },
-            { "ceil",     [&] (const thorin::Continuation* cont) { return world.ceil(cont->param(1)); } },
-            { "floor",    [&] (const thorin::Continuation* cont) { return world.floor(cont->param(1)); } },
-            { "fmin",     [&] (const thorin::Continuation* cont) { return world.fmin(cont->param(1), cont->param(2)); } },
-            { "fmax",     [&] (const thorin::Continuation* cont) { return world.fmax(cont->param(1), cont->param(2)); } },
-            { "cos",      [&] (const thorin::Continuation* cont) { return world.cos(cont->param(1)); } },
-            { "sin",      [&] (const thorin::Continuation* cont) { return world.sin(cont->param(1)); } },
-            { "tan",      [&] (const thorin::Continuation* cont) { return world.tan(cont->param(1)); } },
-            { "acos",     [&] (const thorin::Continuation* cont) { return world.acos(cont->param(1)); } },
-            { "asin",     [&] (const thorin::Continuation* cont) { return world.asin(cont->param(1)); } },
-            { "atan",     [&] (const thorin::Continuation* cont) { return world.atan(cont->param(1)); } },
-            { "atan2",    [&] (const thorin::Continuation* cont) { return world.atan2(cont->param(1), cont->param(2)); } },
-            { "sqrt",     [&] (const thorin::Continuation* cont) { return world.sqrt(cont->param(1)); } },
-            { "cbrt",     [&] (const thorin::Continuation* cont) { return world.cbrt(cont->param(1)); } },
-            { "pow",      [&] (const thorin::Continuation* cont) { return world.pow(cont->param(1), cont->param(2)); } },
-            { "exp",      [&] (const thorin::Continuation* cont) { return world.exp(cont->param(1)); } },
-            { "exp2",     [&] (const thorin::Continuation* cont) { return world.exp2(cont->param(1)); } },
-            { "log",      [&] (const thorin::Continuation* cont) { return world.log(cont->param(1)); } },
-            { "log2",     [&] (const thorin::Continuation* cont) { return world.log2(cont->param(1)); } },
-            { "log10",    [&] (const thorin::Continuation* cont) { return world.log10(cont->param(1)); } },
-            { "isnan",    [&] (const thorin::Continuation* cont) { return isnan(cont->param(1)); } },
-            { "isfinite", [&] (const thorin::Continuation* cont) { return isfinite(cont->param(1)); } },
+        static const std::unordered_map<std::string, std::function<const thorin::Def* (Emitter*, const thorin::Continuation*)>> functions = {
+            { "fabs",     [] (Emitter* self, const thorin::Continuation* cont) { return self->world.fabs(cont->param(1)); } },
+            { "copysign", [] (Emitter* self, const thorin::Continuation* cont) { return self->world.copysign(cont->param(1), cont->param(2)); } },
+            { "signbit",  [] (Emitter* self, const thorin::Continuation* cont) { (void)self; return signbit(cont->param(1)); } },
+            { "round",    [] (Emitter* self, const thorin::Continuation* cont) { return self->world.round(cont->param(1)); } },
+            { "ceil",     [] (Emitter* self, const thorin::Continuation* cont) { return self->world.ceil(cont->param(1)); } },
+            { "floor",    [] (Emitter* self, const thorin::Continuation* cont) { return self->world.floor(cont->param(1)); } },
+            { "fmin",     [] (Emitter* self, const thorin::Continuation* cont) { return self->world.fmin(cont->param(1), cont->param(2)); } },
+            { "fmax",     [] (Emitter* self, const thorin::Continuation* cont) { return self->world.fmax(cont->param(1), cont->param(2)); } },
+            { "cos",      [] (Emitter* self, const thorin::Continuation* cont) { return self->world.cos(cont->param(1)); } },
+            { "sin",      [] (Emitter* self, const thorin::Continuation* cont) { return self->world.sin(cont->param(1)); } },
+            { "tan",      [] (Emitter* self, const thorin::Continuation* cont) { return self->world.tan(cont->param(1)); } },
+            { "acos",     [] (Emitter* self, const thorin::Continuation* cont) { return self->world.acos(cont->param(1)); } },
+            { "asin",     [] (Emitter* self, const thorin::Continuation* cont) { return self->world.asin(cont->param(1)); } },
+            { "atan",     [] (Emitter* self, const thorin::Continuation* cont) { return self->world.atan(cont->param(1)); } },
+            { "atan2",    [] (Emitter* self, const thorin::Continuation* cont) { return self->world.atan2(cont->param(1), cont->param(2)); } },
+            { "sqrt",     [] (Emitter* self, const thorin::Continuation* cont) { return self->world.sqrt(cont->param(1)); } },
+            { "cbrt",     [] (Emitter* self, const thorin::Continuation* cont) { return self->world.cbrt(cont->param(1)); } },
+            { "pow",      [] (Emitter* self, const thorin::Continuation* cont) { return self->world.pow(cont->param(1), cont->param(2)); } },
+            { "exp",      [] (Emitter* self, const thorin::Continuation* cont) { return self->world.exp(cont->param(1)); } },
+            { "exp2",     [] (Emitter* self, const thorin::Continuation* cont) { return self->world.exp2(cont->param(1)); } },
+            { "log",      [] (Emitter* self, const thorin::Continuation* cont) { return self->world.log(cont->param(1)); } },
+            { "log2",     [] (Emitter* self, const thorin::Continuation* cont) { return self->world.log2(cont->param(1)); } },
+            { "log10",    [] (Emitter* self, const thorin::Continuation* cont) { return self->world.log10(cont->param(1)); } },
+            { "isnan",    [] (Emitter* self, const thorin::Continuation* cont) { (void)self; return isnan(cont->param(1)); } },
+            { "isfinite", [] (Emitter* self, const thorin::Continuation* cont) { (void)self; return isfinite(cont->param(1)); } },
         };
         assert(functions.count(cont->name()) > 0);
         enter(cont);
-        jump(cont->params().back(), functions.at(cont->name())(cont));
+        jump(cont->params().back(), functions.at(cont->name())(this, cont));
     }
     cont->set_filter(cont->all_true_filter());
     return cont;

--- a/src/emit.cpp
+++ b/src/emit.cpp
@@ -909,7 +909,7 @@ const thorin::Def* Emitter::builtin(const ast::FnDecl& fn_decl, thorin::Continua
         static const std::unordered_map<std::string, std::function<const thorin::Def* (Emitter*, const thorin::Continuation*)>> functions = {
             { "fabs",     [] (Emitter* self, const thorin::Continuation* cont) { return self->world.fabs(cont->param(1)); } },
             { "copysign", [] (Emitter* self, const thorin::Continuation* cont) { return self->world.copysign(cont->param(1), cont->param(2)); } },
-            { "signbit",  [] (Emitter* self, const thorin::Continuation* cont) { (void)self; return signbit(cont->param(1)); } },
+            { "signbit",  [] (Emitter*     , const thorin::Continuation* cont) { return signbit(cont->param(1)); } },
             { "round",    [] (Emitter* self, const thorin::Continuation* cont) { return self->world.round(cont->param(1)); } },
             { "ceil",     [] (Emitter* self, const thorin::Continuation* cont) { return self->world.ceil(cont->param(1)); } },
             { "floor",    [] (Emitter* self, const thorin::Continuation* cont) { return self->world.floor(cont->param(1)); } },
@@ -930,8 +930,8 @@ const thorin::Def* Emitter::builtin(const ast::FnDecl& fn_decl, thorin::Continua
             { "log",      [] (Emitter* self, const thorin::Continuation* cont) { return self->world.log(cont->param(1)); } },
             { "log2",     [] (Emitter* self, const thorin::Continuation* cont) { return self->world.log2(cont->param(1)); } },
             { "log10",    [] (Emitter* self, const thorin::Continuation* cont) { return self->world.log10(cont->param(1)); } },
-            { "isnan",    [] (Emitter* self, const thorin::Continuation* cont) { (void)self; return isnan(cont->param(1)); } },
-            { "isfinite", [] (Emitter* self, const thorin::Continuation* cont) { (void)self; return isfinite(cont->param(1)); } },
+            { "isnan",    [] (Emitter*     , const thorin::Continuation* cont) { return isnan(cont->param(1)); } },
+            { "isfinite", [] (Emitter*     , const thorin::Continuation* cont) { return isfinite(cont->param(1)); } },
         };
         assert(functions.count(cont->name()) > 0);
         enter(cont);


### PR DESCRIPTION
The usage of static and reference based lambdas is undefined behaviour as the initial reference can be destroyed, but the std::function remains.
This PR fixes that and also the issue AnyDSL/thorin#134