### PR TITLE
Accept ProjExpr in filters.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -55,6 +55,7 @@ add_test(NAME simple_mut         COMMAND artic --print-ast --warnings-as-errors 
 add_test(NAME simple_static      COMMAND artic --print-ast ${CMAKE_CURRENT_SOURCE_DIR}/simple/static.art)
 add_test(NAME simple_arrays1     COMMAND artic --print-ast ${CMAKE_CURRENT_SOURCE_DIR}/simple/arrays1.art)
 add_test(NAME simple_arrays2     COMMAND artic --print-ast ${CMAKE_CURRENT_SOURCE_DIR}/simple/arrays2.art)
+add_test(NAME simple_arrays3     COMMAND artic --print-ast ${CMAKE_CURRENT_SOURCE_DIR}/simple/arrays3.art)
 add_test(NAME simple_sort        COMMAND artic --print-ast ${CMAKE_CURRENT_SOURCE_DIR}/simple/sort.art)
 add_test(NAME simple_filters1    COMMAND artic --print-ast ${CMAKE_CURRENT_SOURCE_DIR}/simple/filters1.art)
 add_test(NAME simple_filters2    COMMAND artic --print-ast ${CMAKE_CURRENT_SOURCE_DIR}/simple/filters2.art)

--- a/test/simple/arrays3.art
+++ b/test/simple/arrays3.art
@@ -1,0 +1,10 @@
+static n = 3;
+
+#[export]
+fn test() {
+    let a = [3; n] : [i32 * n];
+    let b = [4; n];
+    let mut c : [i32 * n];
+    c(0) = a(0);
+    c(1) = b(1);
+}


### PR DESCRIPTION
This is required to extract members of structs in a filter. As an absolute baseline, the lhs is checked to be a legal element in a filter, but there are potential problems, for instance with mutable pointers, that might break in the future. If something like this comes up we will fix it.