### PR TITLE
Allow defaults in function signatures with syntax (..., p = e, ...).

### DIFF
--- a/include/artic/ast.h
+++ b/include/artic/ast.h
@@ -1640,6 +1640,24 @@ struct ImplicitParamPtrn : public Ptrn {
     void print(Printer&) const override;
 };
 
+struct DefaultParamPtrn : public Ptrn {
+    Ptr<Ptrn> underlying;
+    Ptr<Expr> default_expr;
+
+    DefaultParamPtrn(const Loc& loc, Ptr<Ptrn>&& underlying, Ptr<Expr>&& default_expr)
+        : Ptrn(loc), underlying(std::move(underlying)), default_expr(std::move(default_expr))
+    {}
+
+    bool is_trivial() const override;
+
+    void emit(Emitter&, const thorin::Def*) const override;
+    const artic::Type* infer(TypeChecker&) override;
+    const artic::Type* check(TypeChecker&, const artic::Type*) override;
+    void bind(NameBinder&) override;
+    void resolve_summons(Summoner&) override;
+    void print(Printer&) const override;
+};
+
 /// A pattern that matches against a structure field.
 struct FieldPtrn : public Ptrn {
     Identifier id;

--- a/include/artic/types.h
+++ b/include/artic/types.h
@@ -301,6 +301,34 @@ private:
     friend class TypeTable;
 };
 
+struct DefaultParamType : public Type {
+    const Type* underlying;
+    const ast::Expr* expr;
+
+    void print(Printer&) const override;
+    bool equals(const Type*) const override;
+    size_t hash() const override;
+    bool contains(const Type*) const override;
+
+    const Type* replace(const ReplaceMap&) const override;
+
+    const thorin::Type* convert(Emitter&) const override;
+    std::string stringify(Emitter&) const override;
+
+    size_t order(std::unordered_set<const Type*>&) const override;
+    void variance(TypeVarMap<TypeVariance>&, bool) const override;
+    void bounds(TypeVarMap<TypeBounds>&, const Type*, bool) const override;
+    bool is_sized(std::unordered_set<const Type*>&) const override;
+private:
+    DefaultParamType(TypeTable& type_table, const Type* underlying, const ast::Expr* expr)
+        : Type(type_table)
+        , underlying(underlying)
+        , expr(expr)
+    {}
+
+    friend class TypeTable;
+};
+
 /// Function type (can represent continuations when the codomain is a `NoRetType`).
 struct FnType : public Type {
     const Type* dom;
@@ -672,6 +700,7 @@ public:
     const PtrType*           ptr_type(const Type*, bool, size_t);
     const RefType*           ref_type(const Type*, bool, size_t);
     const ImplicitParamType* implicit_param_type(const Type*);
+    const DefaultParamType*  default_param_type(const Type*, const ast::Expr*);
     const FnType*            fn_type(const Type*, const Type*);
     const FnType*            cn_type(const Type*);
     const BottomType*        bottom_type();

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -663,6 +663,10 @@ bool ImplicitParamPtrn::is_trivial() const {
     return underlying->is_trivial();
 }
 
+bool DefaultParamPtrn::is_trivial() const {
+    return underlying->is_trivial();
+}
+
 void FieldPtrn::collect_bound_ptrns(std::vector<const IdPtrn*>& bound_ptrns) const {
     if (ptrn)
         ptrn->collect_bound_ptrns(bound_ptrns);

--- a/src/bind.cpp
+++ b/src/bind.cpp
@@ -352,6 +352,11 @@ void ImplicitParamPtrn::bind(artic::NameBinder& binder) {
     underlying->bind(binder);
 }
 
+void DefaultParamPtrn::bind(artic::NameBinder& binder) {
+    underlying->bind(binder);
+    default_expr->bind(binder);
+}
+
 void FieldPtrn::bind(NameBinder& binder) {
     if (ptrn) binder.bind(*ptrn);
 }

--- a/src/emit.cpp
+++ b/src/emit.cpp
@@ -688,6 +688,8 @@ const thorin::Def* Emitter::down_cast(const thorin::Def* def, const Type* from, 
 
     if (to->isa<ImplicitParamType>())
         return def;
+    if (to->isa<DefaultParamType>())
+        return def;
 
     auto to_ptr_type = to->isa<PtrType>();
     // Casting a value to a pointer to the type of the value effectively creates an allocation
@@ -1786,6 +1788,10 @@ void ImplicitParamPtrn::emit(artic::Emitter& emitter, const thorin::Def* value) 
     underlying->emit(emitter, value);
 }
 
+void DefaultParamPtrn::emit(artic::Emitter& emitter, const thorin::Def* value) const {
+    underlying->emit(emitter, value);
+}
+
 void FieldPtrn::emit(Emitter& emitter, const thorin::Def* value) const {
     emitter.emit(*ptrn, value);
 }
@@ -1900,11 +1906,19 @@ std::string ImplicitParamType::stringify(Emitter& emitter) const {
     return "implicit_" + underlying->stringify(emitter);
 }
 
+std::string DefaultParamType::stringify(Emitter& emitter) const {
+    return "default_" + underlying->stringify(emitter);
+}
+
 std::string FnType::stringify(Emitter& emitter) const {
     return "fn_" + dom->stringify(emitter) + "_" + codom->stringify(emitter);
 }
 
 const thorin::Type* ImplicitParamType::convert(artic::Emitter& emitter) const {
+    return underlying->convert(emitter);
+}
+
+const thorin::Type* DefaultParamType::convert(artic::Emitter& emitter) const {
     return underlying->convert(emitter);
 }
 

--- a/src/print.cpp
+++ b/src/print.cpp
@@ -411,6 +411,13 @@ void ImplicitParamPtrn::print(Printer& p) const {
     underlying->print(p);
 }
 
+void DefaultParamPtrn::print(Printer& p) const {
+    p << log::keyword_style("default") << ' ';
+    underlying->print(p);
+    p << " = ";
+    default_expr->print(p);
+}
+
 void FieldPtrn::print(Printer& p) const {
     if (is_etc()) {
         p << "...";
@@ -769,6 +776,11 @@ void RefType::print(Printer& p) const {
 
 void ImplicitParamType::print(artic::Printer& p) const {
     p << "implicit ";
+    underlying->print(p);
+}
+
+void DefaultParamType::print(artic::Printer& p) const {
+    p << "default ";
     underlying->print(p);
 }
 

--- a/src/summoner.cpp
+++ b/src/summoner.cpp
@@ -60,7 +60,8 @@ void TypedExpr::resolve_summons(artic::Summoner& summoner) {
 }
 
 void SummonExpr::resolve_summons(artic::Summoner& summoner) {
-    resolved = summoner.resolve(type, loc);
+    if (!resolved)
+        resolved = summoner.resolve(type, loc);
 }
 
 void FieldExpr::resolve_summons(artic::Summoner& summoner) {
@@ -221,6 +222,12 @@ void IdPtrn::resolve_summons(artic::Summoner& summoner) {
 
 void ImplicitParamPtrn::resolve_summons(artic::Summoner& summoner) {
     summoner.insert(underlying->type, underlying->to_expr());
+}
+
+void DefaultParamPtrn::resolve_summons(artic::Summoner& summoner) {
+    default_expr->resolve_summons(summoner);
+
+    underlying->resolve_summons(summoner);
 }
 
 void FieldPtrn::resolve_summons(artic::Summoner& summoner) {

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -58,6 +58,13 @@ bool ImplicitParamType::equals(const artic::Type* other) const {
         other->as<ImplicitParamType>()->underlying == underlying;
 }
 
+bool DefaultParamType::equals(const artic::Type* other) const {
+    return
+        other->isa<DefaultParamType>() &&
+        other->as<DefaultParamType>()->underlying == underlying &&
+        other->as<DefaultParamType>()->expr == expr;
+}
+
 bool FnType::equals(const Type* other) const {
     return
         other->isa<FnType>() &&
@@ -120,6 +127,13 @@ size_t ImplicitParamType::hash() const {
         .combine(underlying);
 }
 
+size_t DefaultParamType::hash() const {
+    return fnv::Hash()
+        .combine(typeid(*this).hash_code())
+        .combine(underlying)
+        .combine(expr);
+}
+
 size_t FnType::hash() const {
     return fnv::Hash()
         .combine(typeid(*this).hash_code())
@@ -161,6 +175,10 @@ bool AddrType::contains(const Type* type) const {
 }
 
 bool ImplicitParamType::contains(const artic::Type* type) const {
+    return type == this || underlying->contains(type);
+}
+
+bool DefaultParamType::contains(const artic::Type* type) const {
     return type == this || underlying->contains(type);
 }
 
@@ -206,6 +224,10 @@ const Type* ImplicitParamType::replace(const artic::ReplaceMap& map) const {
     return type_table.implicit_param_type(underlying->replace(map));
 }
 
+const Type* DefaultParamType::replace(const artic::ReplaceMap& map) const {
+    return type_table.default_param_type(underlying->replace(map), expr);
+}
+
 const Type* FnType::replace(const std::unordered_map<const TypeVar*, const Type*>& map) const {
     return type_table.fn_type(dom->replace(map), codom->replace(map));
 }
@@ -230,6 +252,10 @@ size_t Type::order(std::unordered_set<const Type*>&) const {
 }
 
 size_t ImplicitParamType::order(std::unordered_set<const Type*>& seen) const {
+    return underlying->order(seen);
+}
+
+size_t DefaultParamType::order(std::unordered_set<const Type*>& seen) const {
     return underlying->order(seen);
 }
 
@@ -294,6 +320,10 @@ void ImplicitParamType::variance(TypeVarMap<artic::TypeVariance>& vars, bool dir
     return underlying->variance(vars, dir);
 }
 
+void DefaultParamType::variance(TypeVarMap<artic::TypeVariance>& vars, bool dir) const {
+    return underlying->variance(vars, dir);
+}
+
 void TypeVar::variance(std::unordered_map<const TypeVar*, TypeVariance>& vars, bool dir) const {
     if (auto it = vars.find(this); it != vars.end()) {
         bool var_dir = it->second == TypeVariance::Covariant ? true : false;
@@ -333,6 +363,10 @@ void ImplicitParamType::bounds(TypeVarMap<artic::TypeBounds>& bounds, const arti
     underlying->bounds(bounds, type, dir);
 }
 
+void DefaultParamType::bounds(TypeVarMap<artic::TypeBounds>& bounds, const artic::Type* type, bool dir) const {
+    underlying->bounds(bounds, type, dir);
+}
+
 void FnType::bounds(std::unordered_map<const TypeVar*, TypeBounds>& bounds, const Type* type, bool dir) const {
     if (auto fn_type = type->isa<FnType>()) {
         dom->bounds(bounds, fn_type->dom, !dir);
@@ -367,6 +401,10 @@ bool Type::is_sized(std::unordered_set<const Type*>&) const {
 }
 
 bool ImplicitParamType::is_sized(std::unordered_set<const Type*>& seen) const {
+    return underlying->is_sized(seen);
+}
+
+bool DefaultParamType::is_sized(std::unordered_set<const Type*>& seen) const {
     return underlying->is_sized(seen);
 }
 
@@ -490,6 +528,9 @@ bool Type::subtype(const Type* other) const {
 
     if (auto implicit = other->isa<ImplicitParamType>())
         return this->subtype(implicit->underlying) || is_unit_type(this);
+
+    if (auto default_type = other->isa<DefaultParamType>())
+        return this->subtype(default_type->underlying) || is_unit_type(this);
 
     auto other_ptr_type = other->isa<PtrType>(); 
 
@@ -676,6 +717,10 @@ const RefType* TypeTable::ref_type(const Type* pointee, bool is_mut, size_t addr
 
 const ImplicitParamType* TypeTable::implicit_param_type(const Type* underlying) {
     return insert<ImplicitParamType>(underlying);
+}
+
+const DefaultParamType* TypeTable::default_param_type(const Type* underlying, const ast::Expr* expr) {
+    return insert<DefaultParamType>(underlying, expr);
 }
 
 const FnType* TypeTable::fn_type(const Type* dom, const Type* codom) {


### PR DESCRIPTION
This hijacks the implicit summoning to also allow for defaults to be specified. Type checking infers a type for the supplied expression first, and then checks that the parameter matches. As a consequence, the following variants are all valid:

* p : t = e
* p = e : t
* p = e, if the expression type can be inferred.