### PR TITLE
Use an Arena for AST nodes

### DIFF
--- a/include/artic/arena.h
+++ b/include/artic/arena.h
@@ -2,6 +2,8 @@
 #define ARTIC_ARENA_H
 
 #include <type_traits>
+#include <memory>
+#include <vector>
 
 template<typename T>
 /** works like unique_ptr but doesn't actually own anything */
@@ -36,6 +38,25 @@ struct arena_ptr {
         other._ptr = _ptr;
         _ptr = tmp;
     }
+};
+
+struct Arena {
+    Arena();
+    ~Arena();
+
+    template<typename T, typename ...Args>
+    arena_ptr<T> make_ptr(Args&& ...args) {
+        void* ptr = alloc(sizeof(T));
+        new (ptr) T (std::forward<Args>(args)...);
+        return arena_ptr<T>(static_cast<T*>(ptr));
+    }
+private:
+    void* alloc(size_t);
+    void grow();
+
+    size_t _block_size;
+    size_t _available;
+    std::vector<void*> _data;
 };
 
 #endif // ARTIC_ARENA_H

--- a/include/artic/arena.h
+++ b/include/artic/arena.h
@@ -11,18 +11,18 @@ struct arena_ptr {
     arena_ptr() : _ptr(nullptr) {}
     arena_ptr(T* ptr) : _ptr(ptr) {}
 
-    template<typename S, std::enable_if_t<std::is_convertible_v<S*, T*>, bool> = true>
-    arena_ptr(arena_ptr<S>& other) : _ptr(static_cast<S*>(other._ptr)) {}
+    // template<typename S, std::enable_if_t<std::is_convertible_v<S*, T*>, bool> = true>
+    // arena_ptr(arena_ptr<S>& other) : _ptr(other._ptr) {}
 
     template<typename S, std::enable_if_t<std::is_convertible_v<S*, T*>, bool> = true>
-    arena_ptr(arena_ptr<S>&& other) : _ptr(static_cast<S*>(other._ptr)) {
+    arena_ptr(arena_ptr<S>&& other) : _ptr(other._ptr) {
         other._ptr = nullptr;
     }
     ~arena_ptr() {
         _ptr = nullptr;
     }
 
-    arena_ptr<T>& operator=(const arena_ptr<T>& other) { _ptr = other._ptr; return *this; }
+    // arena_ptr<T>& operator=(const arena_ptr<T>& other) { _ptr = other._ptr; return *this; }
     arena_ptr<T>& operator=(arena_ptr<T>&& other) { _ptr = other._ptr; other._ptr = nullptr; return *this; }
 
     T* operator->() const { return _ptr; }

--- a/include/artic/arena.h
+++ b/include/artic/arena.h
@@ -1,0 +1,41 @@
+#ifndef ARTIC_ARENA_H
+#define ARTIC_ARENA_H
+
+#include <type_traits>
+
+template<typename T>
+/** works like unique_ptr but doesn't actually own anything */
+struct arena_ptr {
+    T* _ptr;
+
+    arena_ptr() : _ptr(nullptr) {}
+    arena_ptr(T* ptr) : _ptr(ptr) {}
+
+    template<typename S, std::enable_if_t<std::is_convertible_v<S*, T*>, bool> = true>
+    arena_ptr(arena_ptr<S>& other) : _ptr(static_cast<S*>(other._ptr)) {}
+
+    template<typename S, std::enable_if_t<std::is_convertible_v<S*, T*>, bool> = true>
+    arena_ptr(arena_ptr<S>&& other) : _ptr(static_cast<S*>(other._ptr)) {
+        other._ptr = nullptr;
+    }
+    ~arena_ptr() {
+        _ptr = nullptr;
+    }
+
+    arena_ptr<T>& operator=(const arena_ptr<T>& other) { _ptr = other._ptr; return *this; }
+    arena_ptr<T>& operator=(arena_ptr<T>&& other) { _ptr = other._ptr; other._ptr = nullptr; return *this; }
+
+    T* operator->() const { return _ptr; }
+    T& operator*() const { return *_ptr; }
+    operator bool() const { return _ptr; }
+
+    T* get() const { return _ptr; }
+
+    void swap(arena_ptr<T>& other) {
+        T* tmp = other._ptr;
+        other._ptr = _ptr;
+        _ptr = tmp;
+    }
+};
+
+#endif // ARTIC_ARENA_H

--- a/include/artic/ast.h
+++ b/include/artic/ast.h
@@ -28,11 +28,6 @@ class Summoner;
 
 template <typename T> using Ptr = arena_ptr<T>;
 template <typename T> using PtrVector = std::vector<Ptr<T>>;
-template <typename T, typename... Args>
-
-Ptr<T> make_ptr(Args&&... args) {
-    return Ptr(new T(std::forward<Args>(args)...));
-}
 
 namespace ast {
 
@@ -157,7 +152,7 @@ struct Ptrn : public Node {
     /// Collect patterns that bind an identifier to a value in this pattern.
     virtual void collect_bound_ptrns(std::vector<const IdPtrn*>&) const;
     /// Rewrites the pattern into an expression
-    virtual const Expr* to_expr() { return as_expr.get(); }
+    virtual const Expr* to_expr(Arena&) { return as_expr.get(); }
     /// Returns true when the pattern is trivial (e.g. always matches).
     virtual bool is_trivial() const = 0;
     /// Emits IR for the pattern, given a value to bind it to.
@@ -1581,7 +1576,7 @@ struct TypedPtrn : public Ptrn {
     void emit(Emitter&, const thorin::Def*) const override;
     const artic::Type* infer(TypeChecker&) override;
     void bind(NameBinder&) override;
-    const Expr* to_expr() override;
+    const Expr* to_expr(Arena&) override;
     void resolve_summons(Summoner&) override;
     void print(Printer&) const override;
 };
@@ -1602,7 +1597,7 @@ struct IdPtrn : public Ptrn {
     const artic::Type* infer(TypeChecker&) override;
     const artic::Type* check(TypeChecker&, const artic::Type*) override;
     void bind(NameBinder&) override;
-    const Expr* to_expr() override;
+    const Expr* to_expr(Arena&) override;
     void resolve_summons(Summoner&) override;
     void print(Printer&) const override;
 };
@@ -1620,7 +1615,7 @@ struct LiteralPtrn : public Ptrn {
     const artic::Type* infer(TypeChecker&) override;
     const artic::Type* check(TypeChecker&, const artic::Type*) override;
     void bind(NameBinder&) override;
-    const Expr* to_expr() override;
+    const Expr* to_expr(Arena&) override;
     void resolve_summons(Summoner&) override {};
     void print(Printer&) const override;
 };

--- a/include/artic/ast.h
+++ b/include/artic/ast.h
@@ -5,6 +5,7 @@
 #include <vector>
 #include <variant>
 
+#include "artic/arena.h"
 #include "artic/loc.h"
 #include "artic/log.h"
 #include "artic/cast.h"
@@ -25,11 +26,12 @@ class TypeChecker;
 class Emitter;
 class Summoner;
 
-template <typename T> using Ptr = std::unique_ptr<T>;
-template <typename T> using PtrVector = std::vector<std::unique_ptr<T>>;
+template <typename T> using Ptr = arena_ptr<T>;
+template <typename T> using PtrVector = std::vector<Ptr<T>>;
 template <typename T, typename... Args>
-std::unique_ptr<T> make_ptr(Args&&... args) {
-    return std::make_unique<T>(std::forward<Args>(args)...);
+
+Ptr<T> make_ptr(Args&&... args) {
+    return Ptr(new T(std::forward<Args>(args)...));
 }
 
 namespace ast {

--- a/include/artic/check.h
+++ b/include/artic/check.h
@@ -14,8 +14,8 @@ namespace artic {
 /// Utility class to perform bidirectional type checking.
 class TypeChecker : public Logger {
 public:
-    TypeChecker(Log& log, TypeTable& type_table)
-        : Logger(log), type_table(type_table)
+    TypeChecker(Log& log, TypeTable& type_table, Arena& arena)
+        : Logger(log), type_table(type_table), _arena(arena)
     {}
 
     TypeTable& type_table;
@@ -82,6 +82,7 @@ public:
 
 private:
     std::unordered_set<const ast::Decl*> decls_;
+    Arena& _arena;
 };
 
 } // namespace artic

--- a/include/artic/emit.h
+++ b/include/artic/emit.h
@@ -154,6 +154,7 @@ std::tuple<Ptr<ast::ModDecl>, bool> compile(
     bool warns_as_errors,
     bool enable_all_warns,
     Arena& arena,
+    TypeTable& table,
     thorin::World& world,
     Log& log);
 

--- a/include/artic/emit.h
+++ b/include/artic/emit.h
@@ -19,11 +19,12 @@ struct StructType;
 /// Helper class for Thorin IR generation.
 class Emitter : public Logger {
 public:
-    Emitter(Log& log, thorin::World& world)
-        : Logger(log), world(world)
+    Emitter(Log& log, thorin::World& world, Arena& arena)
+        : Logger(log), world(world), arena(arena)
     {}
 
     thorin::World& world;
+    Arena& arena;
 
     struct State {
         const thorin::Def* mem = nullptr;
@@ -147,12 +148,12 @@ private:
 
 /// Helper function to compile a set of files and generate an AST and a thorin module.
 /// Errors are reported in the log, and this function returns true on success.
-bool compile(
+Ptr<ast::ModDecl> compile(
     const std::vector<std::string>& file_names,
     const std::vector<std::string>& file_data,
     bool warns_as_errors,
     bool enable_all_warns,
-    ast::ModDecl& program,
+    Arena& arena,
     thorin::World& world,
     Log& log);
 

--- a/include/artic/emit.h
+++ b/include/artic/emit.h
@@ -148,7 +148,7 @@ private:
 
 /// Helper function to compile a set of files and generate an AST and a thorin module.
 /// Errors are reported in the log, and this function returns true on success.
-Ptr<ast::ModDecl> compile(
+std::tuple<Ptr<ast::ModDecl>, bool> compile(
     const std::vector<std::string>& file_names,
     const std::vector<std::string>& file_data,
     bool warns_as_errors,

--- a/include/artic/parser.h
+++ b/include/artic/parser.h
@@ -17,7 +17,7 @@ namespace artic {
 /// Generates an AST from a stream of tokens.
 class Parser : public Logger {
 public:
-    Parser(Log& log, Lexer&);
+    Parser(Log& log, Lexer&, Arena&);
 
     /// Parses a program read from the Lexer object.
     /// Errors are reported by the Logger.
@@ -208,6 +208,7 @@ private:
     Token ahead_[max_ahead];
     Lexer& lexer_;
     Loc prev_;
+    Arena& _arena;
 };
 
 } // namespace artic

--- a/include/artic/summoner.h
+++ b/include/artic/summoner.h
@@ -11,8 +11,8 @@ namespace artic {
 
 class Summoner : public Logger {
 public:
-    Summoner(Log& log)
-        : Logger(log)
+    Summoner(Log& log, Arena& arena)
+        : Logger(log), _arena(arena)
     {}
 
     /// Eliminates all SummonExpr from the program
@@ -27,6 +27,8 @@ private:
 
     bool error = false;
     std::vector<TypeMap<const ast::Expr*>> scopes;
+
+    Arena& _arena;
 
     friend ast::SummonExpr;
     friend ast::ImplicitDecl;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,7 +25,7 @@ add_library(libartic
     summoner.cpp
     types.cpp)
 
-set_target_properties(libartic PROPERTIES PREFIX "" CXX_STANDARD 17)
+set_target_properties(libartic PROPERTIES PREFIX "" CXX_STANDARD 20)
 
 target_link_libraries(libartic PUBLIC ${Thorin_LIBRARIES})
 target_include_directories(libartic PUBLIC ${Thorin_INCLUDE_DIRS} ../include)
@@ -35,7 +35,7 @@ if (${COLORIZE})
 endif()
 
 add_executable(artic main.cpp)
-set_target_properties(artic PROPERTIES CXX_STANDARD 17)
+set_target_properties(artic PROPERTIES CXX_STANDARD 20)
 target_compile_definitions(artic PUBLIC -DARTIC_VERSION_MAJOR=${PROJECT_VERSION_MAJOR} -DARTIC_VERSION_MINOR=${PROJECT_VERSION_MINOR})
 target_link_libraries(artic PUBLIC libartic)
 if (Thorin_HAS_JSON_SUPPORT)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,6 +14,7 @@ add_library(libartic
     ../include/artic/symbol.h
     ../include/artic/token.h
     ../include/artic/types.h
+    arena.cpp
     ast.cpp
     bind.cpp
     check.cpp

--- a/src/arena.cpp
+++ b/src/arena.cpp
@@ -1,0 +1,27 @@
+#include "artic/arena.h"
+
+#include <cstdlib>
+
+Arena::Arena() : _block_size(4096) {
+    _data = { malloc(_block_size) };
+    _available = _block_size;
+}
+
+Arena::~Arena() {
+    for (auto& ptr : _data)
+        free(ptr);
+}
+
+void Arena::grow() {
+    _block_size *= 2;
+    _data.push_back( malloc(_block_size) );
+    _available = _block_size;
+}
+
+void* Arena::alloc(size_t size) {
+    while (size > _available)
+        grow();
+    size_t ptr = reinterpret_cast<size_t>(_data.back()) + _block_size - _available;
+    _available -= size;
+    return reinterpret_cast<void*>(ptr);
+}

--- a/src/arena.cpp
+++ b/src/arena.cpp
@@ -8,6 +8,9 @@ Arena::Arena() : _block_size(4096) {
 }
 
 Arena::~Arena() {
+    for (auto [f, p] : _cleanup) {
+        f(p);
+    }
     for (auto& ptr : _data)
         free(ptr);
 }

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -619,10 +619,10 @@ bool TypedPtrn::is_trivial() const {
     return !ptrn || ptrn->is_trivial();
 }
 
-const Expr* TypedPtrn::to_expr() {
+const Expr* TypedPtrn::to_expr(Arena& arena) {
     if (!ptrn)
         return nullptr;
-    return ptrn->to_expr();
+    return ptrn->to_expr(arena);
 }
 
 void IdPtrn::collect_bound_ptrns(std::vector<const IdPtrn*>& bound_ptrns) const {
@@ -635,7 +635,7 @@ bool IdPtrn::is_trivial() const {
     return !sub_ptrn || sub_ptrn->is_trivial();
 }
 
-const Expr* IdPtrn::to_expr() {
+const Expr* IdPtrn::to_expr(Arena& arena) {
     if (as_expr)
         return as_expr.get();
     Identifier id = decl->id;
@@ -644,7 +644,7 @@ const Expr* IdPtrn::to_expr() {
     Path path = Path(loc, std::move(elems));
     path.start_decl = decl.get();
     path.is_value = true;
-    as_expr = make_ptr<PathExpr>(std::move(path));
+    as_expr = arena.make_ptr<PathExpr>(std::move(path));
     return as_expr.get();
 }
 
@@ -652,10 +652,10 @@ bool LiteralPtrn::is_trivial() const {
     return false;
 }
 
-const Expr* LiteralPtrn::to_expr() {
+const Expr* LiteralPtrn::to_expr(Arena& arena) {
     if (as_expr)
         return as_expr.get();
-    as_expr = make_ptr<LiteralExpr>(loc, lit);
+    as_expr = arena.make_ptr<LiteralExpr>(loc, lit);
     return as_expr.get();
 }
 

--- a/src/emit.cpp
+++ b/src/emit.cpp
@@ -2053,7 +2053,7 @@ struct MemBuf : public std::streambuf {
     }
 };
 
-Ptr<ast::ModDecl> compile(
+std::tuple<Ptr<ast::ModDecl>, bool> compile(
     const std::vector<std::string>& file_names,
     const std::vector<std::string>& file_data,
     bool warns_as_errors,
@@ -2075,7 +2075,7 @@ Ptr<ast::ModDecl> compile(
         parser.warns_as_errors = warns_as_errors;
         auto module = parser.parse();
         if (log.errors > 0)
-            return nullptr;
+            return std::make_tuple(std::move(program), false);
 
         program->decls.insert(
             program->decls.end(),
@@ -2098,13 +2098,13 @@ Ptr<ast::ModDecl> compile(
     Summoner summoner(log, arena);
 
     if (!name_binder.run(*program) || !type_checker.run(*program) || !summoner.run(*program))
-        return nullptr;
+        return std::make_tuple(std::move(program), false);
 
     Emitter emitter(log, world, arena);
     emitter.warns_as_errors = warns_as_errors;
     if (!emitter.run(*program))
-        return nullptr;
-    return program;
+        return std::make_tuple(std::move(program), false);
+    return std::make_tuple(std::move(program), true);
 }
 
 } // namespace artic
@@ -2121,5 +2121,5 @@ bool compile(
     log::Output out(error_stream, false);
     Log log(out, &locator);
     Arena arena;
-    return artic::compile(file_names, file_data, false, false, arena, world, log);
+    return get<1>(artic::compile(file_names, file_data, false, false, arena, world, log));
 }

--- a/src/emit.cpp
+++ b/src/emit.cpp
@@ -204,7 +204,7 @@ private:
                         assert(literal_ptrn->lit.as_string().size() + 1 == member_count);
                         const char* str = literal_ptrn->lit.as_string().c_str();
                         for (size_t j = 0; j < member_count; ++j) {
-                            auto char_ptrn = make_ptr<ast::LiteralPtrn>(literal_ptrn->loc, uint8_t(str[j]));
+                            auto char_ptrn = emitter.arena.make_ptr<ast::LiteralPtrn>(literal_ptrn->loc, uint8_t(str[j]));
                             char_ptrn->type = type->type_table.prim_type(ast::PrimType::U8);
                             new_elems[j] = char_ptrn.get();
                             tmp_ptrns.emplace_back(std::move(char_ptrn));
@@ -1317,12 +1317,12 @@ const thorin::Def* ProjExpr::emit(Emitter& emitter) const {
     return emitter.world.extract(emitter.emit(*expr), index, emitter.debug_info(*this));
 }
 
-static inline std::pair<Ptr<IdPtrn>, Ptr<TupleExpr>> dummy_case(const Loc& loc, const artic::Type* type) {
+static inline std::pair<Ptr<IdPtrn>, Ptr<TupleExpr>> dummy_case(const Loc& loc, const artic::Type* type, Arena& arena) {
     // Create a dummy wildcard pattern '_' and empty tuple '()'
     // for the else/break branches of an `if let`/`while let`.
-    auto anon_decl   = make_ptr<ast::PtrnDecl>(loc, Identifier(loc, "_"), false);
-    auto anon_ptrn   = make_ptr<ast::IdPtrn>(loc, std::move(anon_decl), nullptr);
-    auto empty_tuple = make_ptr<ast::TupleExpr>(loc, PtrVector<ast::Expr>());
+    auto anon_decl   = arena.make_ptr<ast::PtrnDecl>(loc, Identifier(loc, "_"), false);
+    auto anon_ptrn   = arena.make_ptr<ast::IdPtrn>(loc, std::move(anon_decl), nullptr);
+    auto empty_tuple = arena.make_ptr<ast::TupleExpr>(loc, PtrVector<ast::Expr>());
     anon_ptrn->type  = type;
     return std::make_pair(std::move(anon_ptrn), std::move(empty_tuple));
 }
@@ -1348,7 +1348,7 @@ const thorin::Def* IfExpr::emit(Emitter& emitter) const {
         auto false_value = if_false ? emitter.emit(*if_false) : emitter.world.tuple({});
         if (join) emitter.jump(join, false_value);
     } else {
-        auto [else_ptrn, empty_tuple] = dummy_case(loc, expr->type);
+        auto [else_ptrn, empty_tuple] = dummy_case(loc, expr->type, emitter.arena);
 
         std::vector<PtrnCompiler::MatchCase> match_cases;
         match_cases.emplace_back(ptrn.get(), if_true.get(), this, join);
@@ -1400,7 +1400,7 @@ const thorin::Def* WhileExpr::emit(Emitter& emitter) const {
         emitter.emit(*body);
         emitter.jump(while_head);
     } else {
-        auto [else_ptrn, empty_tuple] = dummy_case(loc, expr->type);
+        auto [else_ptrn, empty_tuple] = dummy_case(loc, expr->type, emitter.arena);
 
         std::vector<PtrnCompiler::MatchCase> match_cases;
         match_cases.emplace_back(ptrn.get(), body.get(), this, while_head);
@@ -2053,16 +2053,17 @@ struct MemBuf : public std::streambuf {
     }
 };
 
-bool compile(
+Ptr<ast::ModDecl> compile(
     const std::vector<std::string>& file_names,
     const std::vector<std::string>& file_data,
     bool warns_as_errors,
     bool enable_all_warns,
-    ast::ModDecl& program,
+    Arena& arena,
     thorin::World& world,
     Log& log)
 {
     assert(file_data.size() == file_names.size());
+    auto program = arena.make_ptr<ast::ModDecl>();
     for (size_t i = 0, n = file_names.size(); i < n; ++i) {
         if (log.locator)
             log.locator->register_file(file_names[i], file_data[i]);
@@ -2070,20 +2071,20 @@ bool compile(
         std::istream is(&mem_buf);
 
         Lexer lexer(log, file_names[i], is);
-        Parser parser(log, lexer);
+        Parser parser(log, lexer, arena);
         parser.warns_as_errors = warns_as_errors;
         auto module = parser.parse();
         if (log.errors > 0)
-            return false;
+            return nullptr;
 
-        program.decls.insert(
-            program.decls.end(),
+        program->decls.insert(
+            program->decls.end(),
             std::make_move_iterator(module->decls.begin()),
             std::make_move_iterator(module->decls.end())
         );
     }
 
-    program.set_super();
+    program->set_super();
 
     NameBinder name_binder(log);
     name_binder.warns_as_errors = warns_as_errors;
@@ -2091,17 +2092,19 @@ bool compile(
         name_binder.warn_on_shadowing = true;
 
     TypeTable type_table;
-    TypeChecker type_checker(log, type_table);
+    TypeChecker type_checker(log, type_table, arena);
     type_checker.warns_as_errors = warns_as_errors;
 
-    Summoner summoner(log);
+    Summoner summoner(log, arena);
 
-    if (!name_binder.run(program) || !type_checker.run(program) || !summoner.run(program))
-        return false;
+    if (!name_binder.run(*program) || !type_checker.run(*program) || !summoner.run(*program))
+        return nullptr;
 
-    Emitter emitter(log, world);
+    Emitter emitter(log, world, arena);
     emitter.warns_as_errors = warns_as_errors;
-    return emitter.run(program);
+    if (!emitter.run(*program))
+        return nullptr;
+    return program;
 }
 
 } // namespace artic
@@ -2117,6 +2120,6 @@ bool compile(
     Locator locator;
     log::Output out(error_stream, false);
     Log log(out, &locator);
-    ast::ModDecl program;
-    return artic::compile(file_names, file_data, false, false, program, world, log);
+    Arena arena;
+    return artic::compile(file_names, file_data, false, false, arena, world, log);
 }

--- a/src/emit.cpp
+++ b/src/emit.cpp
@@ -2059,6 +2059,7 @@ std::tuple<Ptr<ast::ModDecl>, bool> compile(
     bool warns_as_errors,
     bool enable_all_warns,
     Arena& arena,
+    TypeTable& type_table,
     thorin::World& world,
     Log& log)
 {
@@ -2091,7 +2092,6 @@ std::tuple<Ptr<ast::ModDecl>, bool> compile(
     if (enable_all_warns)
         name_binder.warn_on_shadowing = true;
 
-    TypeTable type_table;
     TypeChecker type_checker(log, type_table, arena);
     type_checker.warns_as_errors = warns_as_errors;
 
@@ -2121,5 +2121,6 @@ bool compile(
     log::Output out(error_stream, false);
     Log log(out, &locator);
     Arena arena;
-    return get<1>(artic::compile(file_names, file_data, false, false, arena, world, log));
+    TypeTable type_table;
+    return get<1>(artic::compile(file_names, file_data, false, false, arena, type_table, world, log));
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -322,11 +322,12 @@ int main(int argc, char** argv) {
     thorin.world().set(std::make_shared<thorin::Stream>(std::cerr));
 
     Arena arena;
+    TypeTable type_table;
     auto [program, success] = compile(
         opts.files, file_data,
         opts.warns_as_errors,
         opts.enable_all_warns,
-        arena, thorin.world(), log);
+        arena, type_table, thorin.world(), log);
 
     log.print_summary();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -322,7 +322,7 @@ int main(int argc, char** argv) {
     thorin.world().set(std::make_shared<thorin::Stream>(std::cerr));
 
     Arena arena;
-    auto program = compile(
+    auto [program, success] = compile(
         opts.files, file_data,
         opts.warns_as_errors,
         opts.enable_all_warns,
@@ -341,7 +341,7 @@ int main(int argc, char** argv) {
         log::out.stream.flush();
     }
 
-    if (!program)
+    if (!success)
         return EXIT_FAILURE;
 
     if (opts.opt_level == 1)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -321,12 +321,12 @@ int main(int argc, char** argv) {
     thorin.world().set(opts.log_level);
     thorin.world().set(std::make_shared<thorin::Stream>(std::cerr));
 
-    ast::ModDecl program;
-    bool success = compile(
+    Arena arena;
+    auto program = compile(
         opts.files, file_data,
         opts.warns_as_errors,
         opts.enable_all_warns,
-        program, thorin.world(), log);
+        arena, thorin.world(), log);
 
     log.print_summary();
 
@@ -336,12 +336,12 @@ int main(int argc, char** argv) {
         Printer p(log::out);
         p.show_implicit_casts = opts.show_implicit_casts;
         p.tab = std::string(opts.tab_width, ' ');
-        program.print(p);
+        program->print(p);
         log::out << '\n';
         log::out.stream.flush();
     }
 
-    if (!success)
+    if (!program)
         return EXIT_FAILURE;
 
     if (opts.opt_level == 1)

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -6,8 +6,8 @@
 
 namespace artic {
 
-Parser::Parser(Log& log, Lexer& lexer)
-    : Logger(log), lexer_(lexer)
+Parser::Parser(Log& log, Lexer& lexer, Arena& arena)
+    : Logger(log), lexer_(lexer), _arena(arena)
 {
     for (int i = 0; i < max_ahead; i++)
         ahead_[i] = Token(Loc());
@@ -20,7 +20,7 @@ Ptr<ast::ModDecl> Parser::parse() {
     PtrVector<ast::Decl> decls;
     while (ahead().tag() != Token::End)
         decls.emplace_back(parse_decl(true));
-    return make_ptr<ast::ModDecl>(tracker(), ast::Identifier(), std::move(decls));
+    return _arena.make_ptr<ast::ModDecl>(tracker(), ast::Identifier(), std::move(decls));
 }
 
 // Declarations --------------------------------------------------------------------
@@ -62,7 +62,7 @@ Ptr<ast::LetDecl> Parser::parse_let_decl() {
     if (accept(Token::Eq))
         init = parse_expr();
     expect(Token::Semi);
-    return make_ptr<ast::LetDecl>(tracker(), std::move(ptrn), std::move(init));
+    return _arena.make_ptr<ast::LetDecl>(tracker(), std::move(ptrn), std::move(init));
 }
 
 Ptr<ast::FnDecl> Parser::parse_fn_decl() {
@@ -87,7 +87,7 @@ Ptr<ast::FnDecl> Parser::parse_fn_decl() {
     Ptr<ast::Type> ret_type;
     if (accept(Token::Arrow)) {
         if (accept(Token::Not))
-            ret_type = make_ptr<ast::NoCodomType>(prev_);
+            ret_type = _arena.make_ptr<ast::NoCodomType>(prev_);
         else
             ret_type = parse_type();
     }
@@ -106,8 +106,8 @@ Ptr<ast::FnDecl> Parser::parse_fn_decl() {
         expect(Token::Semi);
     }
 
-    auto fn = make_ptr<ast::FnExpr>(tracker(), std::move(filter), std::move(param), std::move(ret_type), std::move(body));
-    return make_ptr<ast::FnDecl>(tracker(), std::move(id), std::move(fn), std::move(type_params));
+    auto fn = _arena.make_ptr<ast::FnExpr>(tracker(), std::move(filter), std::move(param), std::move(ret_type), std::move(body));
+    return _arena.make_ptr<ast::FnDecl>(tracker(), std::move(id), std::move(fn), std::move(type_params));
 }
 
 Ptr<ast::FieldDecl> Parser::parse_field_decl(bool is_tuple_like) {
@@ -119,7 +119,7 @@ Ptr<ast::FieldDecl> Parser::parse_field_decl(bool is_tuple_like) {
     Ptr<ast::Expr> init;
     if (accept(Token::Eq))
         init = parse_expr();
-    return make_ptr<ast::FieldDecl>(tracker(), std::move(id), std::move(type), std::move(init));
+    return _arena.make_ptr<ast::FieldDecl>(tracker(), std::move(id), std::move(type), std::move(init));
 }
 
 Ptr<ast::StructDecl> Parser::parse_struct_decl() {
@@ -145,7 +145,7 @@ Ptr<ast::StructDecl> Parser::parse_struct_decl() {
         expect(Token::Semi);
     }
 
-    return make_ptr<ast::StructDecl>(tracker(), std::move(id), std::move(type_params), std::move(fields), is_tuple_like);
+    return _arena.make_ptr<ast::StructDecl>(tracker(), std::move(id), std::move(type_params), std::move(fields), is_tuple_like);
 }
 
 Ptr<ast::OptionDecl> Parser::parse_option_decl() {
@@ -163,7 +163,7 @@ Ptr<ast::OptionDecl> Parser::parse_option_decl() {
         });
         has_fields = true;
     }
-    return make_ptr<ast::OptionDecl>(tracker(), std::move(id), std::move(param), std::move(fields), has_fields);
+    return _arena.make_ptr<ast::OptionDecl>(tracker(), std::move(id), std::move(param), std::move(fields), has_fields);
 }
 
 Ptr<ast::EnumDecl> Parser::parse_enum_decl() {
@@ -182,7 +182,7 @@ Ptr<ast::EnumDecl> Parser::parse_enum_decl() {
     });
     if (options.empty())
         error(tracker(), "enums require at least one alternative");
-    return make_ptr<ast::EnumDecl>(tracker(), std::move(id), std::move(type_params), std::move(options));
+    return _arena.make_ptr<ast::EnumDecl>(tracker(), std::move(id), std::move(type_params), std::move(options));
 }
 
 Ptr<ast::TypeDecl> Parser::parse_type_decl() {
@@ -197,7 +197,7 @@ Ptr<ast::TypeDecl> Parser::parse_type_decl() {
     expect(Token::Eq);
     auto aliased_type = parse_type();
     expect(Token::Semi);
-    return make_ptr<ast::TypeDecl>(tracker(), std::move(id), std::move(type_params), std::move(aliased_type));
+    return _arena.make_ptr<ast::TypeDecl>(tracker(), std::move(id), std::move(type_params), std::move(aliased_type));
 }
 
 Ptr<ast::ImplicitDecl> Parser::parse_implicit_decl() {
@@ -211,7 +211,7 @@ Ptr<ast::ImplicitDecl> Parser::parse_implicit_decl() {
     expect(Token::Eq);
     auto value = parse_expr(true);
     expect(Token::Semi);
-    return make_ptr<ast::ImplicitDecl>(tracker(), std::move(type), std::move(value));
+    return _arena.make_ptr<ast::ImplicitDecl>(tracker(), std::move(type), std::move(value));
 }
 
 Ptr<ast::StaticDecl> Parser::parse_static_decl() {
@@ -228,13 +228,13 @@ Ptr<ast::StaticDecl> Parser::parse_static_decl() {
     if (accept(Token::Eq))
         init = parse_expr();
     expect(Token::Semi);
-    return make_ptr<ast::StaticDecl>(tracker(), std::move(id), std::move(type), std::move(init), is_mut);
+    return _arena.make_ptr<ast::StaticDecl>(tracker(), std::move(id), std::move(type), std::move(init), is_mut);
 }
 
 Ptr<ast::TypeParam> Parser::parse_type_param() {
     Tracker tracker(this);
     auto id = parse_id();
-    return make_ptr<ast::TypeParam>(tracker(), std::move(id));
+    return _arena.make_ptr<ast::TypeParam>(tracker(), std::move(id));
 }
 
 Ptr<ast::TypeParamList> Parser::parse_type_params() {
@@ -244,7 +244,7 @@ Ptr<ast::TypeParamList> Parser::parse_type_params() {
     parse_list(Token::RBracket, Token::Comma, [&] {
         type_params.emplace_back(parse_type_param());
     });
-    return make_ptr<ast::TypeParamList>(tracker(), std::move(type_params));
+    return _arena.make_ptr<ast::TypeParamList>(tracker(), std::move(type_params));
 }
 
 Ptr<ast::ModDecl> Parser::parse_mod_decl() {
@@ -256,7 +256,7 @@ Ptr<ast::ModDecl> Parser::parse_mod_decl() {
     while (ahead().tag() != Token::End && ahead().tag() != Token::RBrace)
         decls.emplace_back(parse_decl(true));
     expect(Token::RBrace);
-    return make_ptr<ast::ModDecl>(tracker(), std::move(id), std::move(decls));
+    return _arena.make_ptr<ast::ModDecl>(tracker(), std::move(id), std::move(decls));
 }
 
 Ptr<ast::UseDecl> Parser::parse_use_decl() {
@@ -273,14 +273,14 @@ Ptr<ast::UseDecl> Parser::parse_use_decl() {
             log::keyword_style("use"), path,
             log::keyword_style("as"));
     }
-    return make_ptr<ast::UseDecl>(tracker(), std::move(path), std::move(id));
+    return _arena.make_ptr<ast::UseDecl>(tracker(), std::move(path), std::move(id));
 }
 
 Ptr<ast::ErrorDecl> Parser::parse_error_decl() {
     Tracker tracker(this);
     error(ahead().loc(), "expected declaration, got '{}'", ahead().string());
     next();
-    return make_ptr<ast::ErrorDecl>(tracker());
+    return _arena.make_ptr<ast::ErrorDecl>(tracker());
 }
 
 // Patterns ------------------------------------------------------------------------
@@ -295,7 +295,7 @@ Ptr<ast::Ptrn> Parser::parse_ptrn(bool allow_types, bool allow_implicits) {
                     if (!allow_types)
                         return parse_error_ptrn();
                     auto type = parse_prim_type(tag);
-                    return make_ptr<ast::TypedPtrn>(type->loc, Ptr<ast::Ptrn>(), std::move(type));
+                    return _arena.make_ptr<ast::TypedPtrn>(type->loc, Ptr<ast::Ptrn>(), std::move(type));
                 }
                 auto id = parse_path_elem();
                 if (ahead().tag() == Token::DblColon ||
@@ -307,8 +307,8 @@ Ptr<ast::Ptrn> Parser::parse_ptrn(bool allow_types, bool allow_implicits) {
                     if (ahead().tag() == Token::LBrace)
                         ptrn = parse_record_ptrn(std::move(path));
                     else if (allow_types) {
-                        auto type = make_ptr<ast::TypeApp>(path.loc, std::move(path));
-                        return make_ptr<ast::TypedPtrn>(path.loc, Ptr<ast::Ptrn>(), std::move(type));
+                        auto type = _arena.make_ptr<ast::TypeApp>(path.loc, std::move(path));
+                        return _arena.make_ptr<ast::TypedPtrn>(path.loc, Ptr<ast::Ptrn>(), std::move(type));
                     } else
                         ptrn = parse_ctor_ptrn(std::move(path));
                 } else
@@ -334,7 +334,7 @@ Ptr<ast::Ptrn> Parser::parse_ptrn(bool allow_types, bool allow_implicits) {
         case Token::Fn:
             if (allow_types) {
                 auto type = parse_type();
-                return make_ptr<ast::TypedPtrn>(type->loc, Ptr<ast::Ptrn>(), std::move(type));
+                return _arena.make_ptr<ast::TypedPtrn>(type->loc, Ptr<ast::Ptrn>(), std::move(type));
             }
             [[fallthrough]];
         case Token::Implicit:
@@ -343,7 +343,7 @@ Ptr<ast::Ptrn> Parser::parse_ptrn(bool allow_types, bool allow_implicits) {
                     return parse_error_ptrn();
                 eat(Token::Implicit);
                 auto underlying = parse_ptrn();
-                return make_ptr<ast::ImplicitParamPtrn>(underlying->loc, std::move(underlying));
+                return _arena.make_ptr<ast::ImplicitParamPtrn>(underlying->loc, std::move(underlying));
             }
         default:
             ptrn = parse_error_ptrn();
@@ -356,24 +356,24 @@ Ptr<ast::Ptrn> Parser::parse_typed_ptrn(Ptr<ast::Ptrn>&& ptrn) {
     Tracker tracker(this, ptrn->loc);
     if (accept(Token::Colon)) {
         auto type = parse_type();
-        return make_ptr<ast::TypedPtrn>(tracker(), std::move(ptrn), std::move(type));
+        return _arena.make_ptr<ast::TypedPtrn>(tracker(), std::move(ptrn), std::move(type));
     }
     return std::move(ptrn);
 }
 
 Ptr<ast::IdPtrn> Parser::parse_id_ptrn(ast::Identifier&& id, bool is_mut) {
     Tracker tracker(this, id.loc);
-    auto decl = make_ptr<ast::PtrnDecl>(tracker(), std::move(id), is_mut);
+    auto decl = _arena.make_ptr<ast::PtrnDecl>(tracker(), std::move(id), is_mut);
     Ptr<ast::Ptrn> sub_ptrn;
     if (accept(Token::As))
         sub_ptrn = parse_ptrn();
-    return make_ptr<ast::IdPtrn>(tracker(), std::move(decl), std::move(sub_ptrn));
+    return _arena.make_ptr<ast::IdPtrn>(tracker(), std::move(decl), std::move(sub_ptrn));
 }
 
 Ptr<ast::LiteralPtrn> Parser::parse_literal_ptrn() {
     Tracker tracker(this);
     auto lit = parse_lit();
-    return make_ptr<ast::LiteralPtrn>(tracker(), lit);
+    return _arena.make_ptr<ast::LiteralPtrn>(tracker(), lit);
 }
 
 Ptr<ast::FieldPtrn> Parser::parse_field_ptrn() {
@@ -389,7 +389,7 @@ Ptr<ast::FieldPtrn> Parser::parse_field_ptrn() {
         expect(Token::Eq);
         ptrn = parse_ptrn();
     }
-    return make_ptr<ast::FieldPtrn>(tracker(), std::move(id), std::move(ptrn));
+    return _arena.make_ptr<ast::FieldPtrn>(tracker(), std::move(id), std::move(ptrn));
 }
 
 Ptr<ast::RecordPtrn> Parser::parse_record_ptrn(ast::Path&& path) {
@@ -403,7 +403,7 @@ Ptr<ast::RecordPtrn> Parser::parse_record_ptrn(ast::Path&& path) {
     auto etc = std::find_if(fields.begin(), fields.end(), [] (auto& field) { return field->is_etc(); });
     if (etc != fields.end() && etc != fields.end() - 1)
         error((*etc)->loc, "'...' can only be used at the end of a record pattern");
-    return make_ptr<ast::RecordPtrn>(tracker(), std::move(path), std::move(fields));
+    return _arena.make_ptr<ast::RecordPtrn>(tracker(), std::move(path), std::move(fields));
 }
 
 Ptr<ast::CtorPtrn> Parser::parse_ctor_ptrn(ast::Path&& path) {
@@ -411,7 +411,7 @@ Ptr<ast::CtorPtrn> Parser::parse_ctor_ptrn(ast::Path&& path) {
     Ptr<ast::Ptrn> arg;
     if (ahead().tag() == Token::LParen)
         arg = parse_tuple_ptrn();
-    return make_ptr<ast::CtorPtrn>(tracker(), std::move(path), std::move(arg));
+    return _arena.make_ptr<ast::CtorPtrn>(tracker(), std::move(path), std::move(arg));
 }
 
 Ptr<ast::Ptrn> Parser::parse_tuple_ptrn(bool allow_types, bool allow_implicits, Token::Tag beg, Token::Tag end) {
@@ -425,7 +425,7 @@ Ptr<ast::Ptrn> Parser::parse_tuple_ptrn(bool allow_types, bool allow_implicits, 
         args[0]->loc = tracker();
         return std::move(args[0]);
     }
-    return make_ptr<ast::TuplePtrn>(tracker(), std::move(args));
+    return _arena.make_ptr<ast::TuplePtrn>(tracker(), std::move(args));
 }
 
 Ptr<ast::ArrayPtrn> Parser::parse_array_ptrn() {
@@ -436,14 +436,14 @@ Ptr<ast::ArrayPtrn> Parser::parse_array_ptrn() {
     parse_list(Token::RBracket, Token::Comma, [&] {
         elems.emplace_back(parse_ptrn());
     });
-    return make_ptr<ast::ArrayPtrn>(tracker(), std::move(elems), is_simd);
+    return _arena.make_ptr<ast::ArrayPtrn>(tracker(), std::move(elems), is_simd);
 }
 
 Ptr<ast::ErrorPtrn> Parser::parse_error_ptrn() {
     Tracker tracker(this);
     error(ahead().loc(), "expected pattern, got '{}'", ahead().string());
     next();
-    return make_ptr<ast::ErrorPtrn>(tracker());
+    return _arena.make_ptr<ast::ErrorPtrn>(tracker());
 }
 
 // Statements ----------------------------------------------------------------------
@@ -461,19 +461,19 @@ Ptr<ast::Stmt> Parser::parse_stmt() {
         default:
             return parse_expr_stmt();
     }
-    return make_ptr<ast::ExprStmt>(tracker(), std::move(expr));
+    return _arena.make_ptr<ast::ExprStmt>(tracker(), std::move(expr));
 }
 
 Ptr<ast::DeclStmt> Parser::parse_decl_stmt() {
     Tracker tracker(this);
     auto decl = parse_decl();
-    return make_ptr<ast::DeclStmt>(tracker(), std::move(decl));
+    return _arena.make_ptr<ast::DeclStmt>(tracker(), std::move(decl));
 }
 
 Ptr<ast::ExprStmt> Parser::parse_expr_stmt() {
     Tracker tracker(this);
     auto expr = parse_expr();
-    return make_ptr<ast::ExprStmt>(tracker(), std::move(expr));
+    return _arena.make_ptr<ast::ExprStmt>(tracker(), std::move(expr));
 }
 
 // Expressions ---------------------------------------------------------------------
@@ -486,18 +486,18 @@ Ptr<ast::Expr> Parser::parse_typed_expr(Ptr<ast::Expr>&& expr) {
     Tracker tracker(this, expr->loc);
     eat(Token::Colon);
     auto type = parse_type();
-    return make_ptr<ast::TypedExpr>(tracker(), std::move(expr), std::move(type));
+    return _arena.make_ptr<ast::TypedExpr>(tracker(), std::move(expr), std::move(type));
 }
 
 Ptr<ast::PathExpr> Parser::parse_path_expr() {
     auto path = parse_path(true);
-    return make_ptr<ast::PathExpr>(std::move(path));
+    return _arena.make_ptr<ast::PathExpr>(std::move(path));
 }
 
 Ptr<ast::LiteralExpr> Parser::parse_literal_expr() {
     Tracker tracker(this);
     auto lit = parse_lit();
-    return make_ptr<ast::LiteralExpr>(tracker(), lit);
+    return _arena.make_ptr<ast::LiteralExpr>(tracker(), lit);
 }
 
 Ptr<ast::SummonExpr> Parser::parse_summon_expr() {
@@ -506,7 +506,7 @@ Ptr<ast::SummonExpr> Parser::parse_summon_expr() {
     expect(Token::LBracket);
     auto t = parse_type();
     expect(Token::RBracket);
-    return make_ptr<ast::SummonExpr>(tracker(), std::move(t));
+    return _arena.make_ptr<ast::SummonExpr>(tracker(), std::move(t));
 }
 
 Ptr<ast::FieldExpr> Parser::parse_field_expr() {
@@ -514,7 +514,7 @@ Ptr<ast::FieldExpr> Parser::parse_field_expr() {
     auto id = parse_id();
     expect(Token::Eq);
     auto expr = parse_expr();
-    return make_ptr<ast::FieldExpr>(tracker(), std::move(id), std::move(expr));
+    return _arena.make_ptr<ast::FieldExpr>(tracker(), std::move(id), std::move(expr));
 }
 
 Ptr<ast::RecordExpr> Parser::parse_record_expr(ast::Path&& path) {
@@ -523,13 +523,13 @@ Ptr<ast::RecordExpr> Parser::parse_record_expr(ast::Path&& path) {
     // path.loc and std::move(path) in the argument list
     // (argument evaluation order is not defined).
     auto loc = path.loc;
-    auto type_app = make_ptr<ast::TypeApp>(loc, std::move(path));
+    auto type_app = _arena.make_ptr<ast::TypeApp>(loc, std::move(path));
     eat(Token::LBrace);
     PtrVector<ast::FieldExpr> fields;
     parse_list(Token::RBrace, Token::Comma, [&] {
         fields.emplace_back(parse_field_expr());
     });
-    return make_ptr<ast::RecordExpr>(tracker(), std::move(type_app), std::move(fields));
+    return _arena.make_ptr<ast::RecordExpr>(tracker(), std::move(type_app), std::move(fields));
 }
 
 Ptr<ast::RecordExpr> Parser::parse_record_expr(Ptr<ast::Expr>&& expr) {
@@ -540,7 +540,7 @@ Ptr<ast::RecordExpr> Parser::parse_record_expr(Ptr<ast::Expr>&& expr) {
     parse_list(Token::RBrace, Token::Comma, [&] {
         fields.emplace_back(parse_field_expr());
     });
-    return make_ptr<ast::RecordExpr>(tracker(), std::move(expr), std::move(fields));
+    return _arena.make_ptr<ast::RecordExpr>(tracker(), std::move(expr), std::move(fields));
 }
 
 Ptr<ast::Expr> Parser::parse_tuple_expr() {
@@ -554,7 +554,7 @@ Ptr<ast::Expr> Parser::parse_tuple_expr() {
         args[0]->loc = tracker();
         return std::move(args[0]);
     }
-    return make_ptr<ast::TupleExpr>(tracker(), std::move(args));
+    return _arena.make_ptr<ast::TupleExpr>(tracker(), std::move(args));
 }
 
 Ptr<ast::Expr> Parser::parse_array_expr() {
@@ -567,16 +567,16 @@ Ptr<ast::Expr> Parser::parse_array_expr() {
         auto size = parse_array_size();
         expect(Token::RBracket);
         if (size)
-            return make_ptr<ast::RepeatArrayExpr>(tracker(), std::move(elems.front()), std::move(*size), is_simd);
-        return make_ptr<ast::ArrayExpr>(tracker(), std::move(elems), is_simd);
+            return _arena.make_ptr<ast::RepeatArrayExpr>(tracker(), std::move(elems.front()), std::move(*size), is_simd);
+        return _arena.make_ptr<ast::ArrayExpr>(tracker(), std::move(elems), is_simd);
     } else if (accept(Token::Comma)) {
         parse_list(Token::RBracket, Token::Comma, [&] {
             elems.emplace_back(parse_expr());
         });
-        return make_ptr<ast::ArrayExpr>(tracker(), std::move(elems), is_simd);
+        return _arena.make_ptr<ast::ArrayExpr>(tracker(), std::move(elems), is_simd);
     } else {
         expect(Token::RBracket);
-        return make_ptr<ast::ArrayExpr>(tracker(), std::move(elems), is_simd);
+        return _arena.make_ptr<ast::ArrayExpr>(tracker(), std::move(elems), is_simd);
     }
 }
 
@@ -633,7 +633,7 @@ Ptr<ast::BlockExpr> Parser::parse_block_expr() {
         break;
     }
     expect(Token::RBrace);
-    return make_ptr<ast::BlockExpr>(tracker(), std::move(stmts), last_semi);
+    return _arena.make_ptr<ast::BlockExpr>(tracker(), std::move(stmts), last_semi);
 }
 
 Ptr<ast::FnExpr> Parser::parse_fn_expr(Ptr<ast::Filter>&& filter, bool nested) {
@@ -654,10 +654,10 @@ Ptr<ast::FnExpr> Parser::parse_fn_expr(Ptr<ast::Filter>&& filter, bool nested) {
         if (args.size() == 1) {
             ptrn = std::move(args.front());
         } else {
-            ptrn = make_ptr<ast::TuplePtrn>(tracker(), std::move(args));
+            ptrn = _arena.make_ptr<ast::TuplePtrn>(tracker(), std::move(args));
         }
     } else if (accept(Token::LogicOr))
-        ptrn = make_ptr<ast::TuplePtrn>(tracker(), PtrVector<ast::Ptrn>{});
+        ptrn = _arena.make_ptr<ast::TuplePtrn>(tracker(), PtrVector<ast::Ptrn>{});
     else
         ptrn = parse_error_ptrn();
 
@@ -673,13 +673,13 @@ Ptr<ast::FnExpr> Parser::parse_fn_expr(Ptr<ast::Filter>&& filter, bool nested) {
             ret_type = parse_type();
         body = parse_expr();
     }
-    return make_ptr<ast::FnExpr>(tracker(), std::move(filter), std::move(ptrn), std::move(ret_type), std::move(body));
+    return _arena.make_ptr<ast::FnExpr>(tracker(), std::move(filter), std::move(ptrn), std::move(ret_type), std::move(body));
 }
 
 Ptr<ast::CallExpr> Parser::parse_call_expr(Ptr<ast::Expr>&& callee) {
     Tracker tracker(this, callee->loc);
     auto args = parse_tuple_expr();
-    return make_ptr<ast::CallExpr>(tracker(), std::move(callee), std::move(args));
+    return _arena.make_ptr<ast::CallExpr>(tracker(), std::move(callee), std::move(args));
 }
 
 Ptr<ast::ProjExpr> Parser::parse_proj_expr(Ptr<ast::Expr>&& expr) {
@@ -688,10 +688,10 @@ Ptr<ast::ProjExpr> Parser::parse_proj_expr(Ptr<ast::Expr>&& expr) {
     if (ahead().is_literal() && ahead().literal().is_integer()) {
         size_t index = ahead().literal().as_integer();
         eat(Token::Lit);
-        return make_ptr<ast::ProjExpr>(tracker(), std::move(expr), index);
+        return _arena.make_ptr<ast::ProjExpr>(tracker(), std::move(expr), index);
     } else {
         auto id = parse_id();
-        return make_ptr<ast::ProjExpr>(tracker(), std::move(expr), std::move(id));
+        return _arena.make_ptr<ast::ProjExpr>(tracker(), std::move(expr), std::move(id));
     }
 }
 
@@ -719,11 +719,11 @@ Ptr<ast::IfExpr> Parser::parse_if_expr() {
 
         auto if_true = parse_block_expr();
         auto if_false = accept_else();
-        return make_ptr<ast::IfExpr>(tracker(), std::move(ptrn), std::move(expr), std::move(if_true), std::move(if_false));
+        return _arena.make_ptr<ast::IfExpr>(tracker(), std::move(ptrn), std::move(expr), std::move(if_true), std::move(if_false));
     } else {
         auto [cond, if_true] = parse_cond_and_block();
         auto if_false = accept_else();
-        return make_ptr<ast::IfExpr>(tracker(), std::move(cond), std::move(if_true), std::move(if_false));
+        return _arena.make_ptr<ast::IfExpr>(tracker(), std::move(cond), std::move(if_true), std::move(if_false));
     }
 }
 
@@ -732,7 +732,7 @@ Ptr<ast::CaseExpr> Parser::parse_case_expr() {
     auto ptrn = parse_ptrn();
     expect(Token::FatArrow);
     auto expr = parse_expr();
-    return make_ptr<ast::CaseExpr>(tracker(), std::move(ptrn), std::move(expr));
+    return _arena.make_ptr<ast::CaseExpr>(tracker(), std::move(ptrn), std::move(expr));
 }
 
 Ptr<ast::MatchExpr> Parser::parse_match_expr() {
@@ -744,7 +744,7 @@ Ptr<ast::MatchExpr> Parser::parse_match_expr() {
     parse_list(Token::RBrace, Token::Comma, [&] {
         cases.emplace_back(parse_case_expr());
     });
-    return make_ptr<ast::MatchExpr>(tracker(), std::move(arg), std::move(cases));
+    return _arena.make_ptr<ast::MatchExpr>(tracker(), std::move(arg), std::move(cases));
 }
 
 Ptr<ast::WhileExpr> Parser::parse_while_expr() {
@@ -756,10 +756,10 @@ Ptr<ast::WhileExpr> Parser::parse_while_expr() {
         auto expr = parse_expr(false);
 
         auto body = parse_block_expr();
-        return make_ptr<ast::WhileExpr>(tracker(), std::move(ptrn), std::move(expr), std::move(body));
+        return _arena.make_ptr<ast::WhileExpr>(tracker(), std::move(ptrn), std::move(expr), std::move(body));
     } else {
         auto[cond, body] = parse_cond_and_block();
-        return make_ptr<ast::WhileExpr>(tracker(), std::move(cond), std::move(body));
+        return _arena.make_ptr<ast::WhileExpr>(tracker(), std::move(cond), std::move(body));
     }
 }
 
@@ -777,7 +777,7 @@ Ptr<ast::Expr> Parser::parse_for_expr() {
         ptrn = parse_tuple_ptrn(false, false, Token::For, Token::In);
     else {
         eat(Token::For);
-        ptrn = make_ptr<ast::TuplePtrn>(tracker(), PtrVector<ast::Ptrn>{});
+        ptrn = _arena.make_ptr<ast::TuplePtrn>(tracker(), PtrVector<ast::Ptrn>{});
     }
 
     auto expr = parse_expr();
@@ -785,7 +785,7 @@ Ptr<ast::Expr> Parser::parse_for_expr() {
     Ptr<ast::CallExpr> call(expr->isa<ast::CallExpr>() ? expr->as<ast::CallExpr>() : nullptr);
     if (!call) {
         error(ahead().loc(), "invalid for loop expression");
-        return make_ptr<ast::ErrorExpr>(tracker());
+        return _arena.make_ptr<ast::ErrorExpr>(tracker());
     }
 
     Ptr<ast::Expr> body;
@@ -796,29 +796,29 @@ Ptr<ast::Expr> Parser::parse_for_expr() {
 
     auto lambda_loc = body->loc;
     // Cannot use body->loc directly because std::move(body) might be executed first
-    auto lambda = make_ptr<ast::FnExpr>(lambda_loc, nullptr, std::move(ptrn), nullptr, std::move(body));
+    auto lambda = _arena.make_ptr<ast::FnExpr>(lambda_loc, nullptr, std::move(ptrn), nullptr, std::move(body));
 
     Ptr<ast::Expr> callee(call->callee.get());
-    call->callee = make_ptr<ast::CallExpr>(call_loc, std::move(callee), std::move(lambda));
-    return make_ptr<ast::ForExpr>(tracker(), std::move(call));
+    call->callee = _arena.make_ptr<ast::CallExpr>(call_loc, std::move(callee), std::move(lambda));
+    return _arena.make_ptr<ast::ForExpr>(tracker(), std::move(call));
 }
 
 Ptr<ast::BreakExpr> Parser::parse_break_expr() {
     Tracker tracker(this);
     eat(Token::Break);
-    return make_ptr<ast::BreakExpr>(tracker());
+    return _arena.make_ptr<ast::BreakExpr>(tracker());
 }
 
 Ptr<ast::ContinueExpr> Parser::parse_continue_expr() {
     Tracker tracker(this);
     eat(Token::Continue);
-    return make_ptr<ast::ContinueExpr>(tracker());
+    return _arena.make_ptr<ast::ContinueExpr>(tracker());
 }
 
 Ptr<ast::ReturnExpr> Parser::parse_return_expr() {
     Tracker tracker(this);
     eat(Token::Return);
-    return make_ptr<ast::ReturnExpr>(tracker());
+    return _arena.make_ptr<ast::ReturnExpr>(tracker());
 }
 
 Ptr<ast::Expr> Parser::parse_primary_expr(bool allow_structs, bool allow_casts) {
@@ -900,14 +900,14 @@ Ptr<ast::UnaryExpr> Parser::parse_prefix_expr(bool allow_structs) {
     if (tag == ast::UnaryExpr::AddrOf && accept(Token::Mut))
         tag = ast::UnaryExpr::AddrOfMut;
     auto expr = parse_primary_expr(allow_structs, false);
-    return make_ptr<ast::UnaryExpr>(tracker(), tag, std::move(expr));
+    return _arena.make_ptr<ast::UnaryExpr>(tracker(), tag, std::move(expr));
 }
 
 Ptr<ast::UnaryExpr> Parser::parse_postfix_expr(Ptr<ast::Expr>&& expr) {
     Tracker tracker(this, expr->loc);
     auto tag = ast::UnaryExpr::tag_from_token(ahead(), false);
     next();
-    return make_ptr<ast::UnaryExpr>(tracker(), tag, std::move(expr));
+    return _arena.make_ptr<ast::UnaryExpr>(tracker(), tag, std::move(expr));
 }
 
 Ptr<ast::Expr> Parser::parse_binary_expr(bool allow_structs, int max_prec) {
@@ -922,7 +922,7 @@ Ptr<ast::Expr> Parser::parse_binary_expr(bool allow_structs, int max_prec) {
         next();
 
         auto right = parse_binary_expr(allow_structs, prec - 1);
-        left = make_ptr<ast::BinaryExpr>(tracker(), tag, std::move(left), std::move(right));
+        left = _arena.make_ptr<ast::BinaryExpr>(tracker(), tag, std::move(left), std::move(right));
     }
     return left;
 }
@@ -933,7 +933,7 @@ Ptr<ast::Expr> Parser::parse_filter_expr(Ptr<ast::Filter>&& filter) {
     if (auto call_expr = expr->isa<ast::CallExpr>()) {
         if (call_expr->callee->isa<ast::FilterExpr>())
             warn(filter->loc, "redundant filter annotation");
-        call_expr->callee = make_ptr<ast::FilterExpr>(tracker(), std::move(filter), std::move(call_expr->callee));
+        call_expr->callee = _arena.make_ptr<ast::FilterExpr>(tracker(), std::move(filter), std::move(call_expr->callee));
     } else
         error(expr->loc, "invalid filter expression");
     return expr;
@@ -943,7 +943,7 @@ Ptr<ast::CastExpr> Parser::parse_cast_expr(Ptr<ast::Expr>&& expr) {
     Tracker tracker(this, expr->loc);
     eat(Token::As);
     auto type = parse_type();
-    return make_ptr<ast::CastExpr>(tracker(), std::move(expr), std::move(type));
+    return _arena.make_ptr<ast::CastExpr>(tracker(), std::move(expr), std::move(type));
 }
 
 Ptr<ast::AsmExpr> Parser::parse_asm_expr() {
@@ -1004,7 +1004,7 @@ error:
     error(ahead().loc(), "expected ':', or ')' in assembly expression");
 
 done:
-    return make_ptr<ast::AsmExpr>(
+    return _arena.make_ptr<ast::AsmExpr>(
        tracker(), std::move(src),
        std::move(ins), std::move(outs),
        std::move(clobs), std::move(opts));
@@ -1014,7 +1014,7 @@ Ptr<ast::ErrorExpr> Parser::parse_error_expr() {
     Tracker tracker(this);
     error(ahead().loc(), "expected expression, got '{}'", ahead().string());
     next();
-    return make_ptr<ast::ErrorExpr>(tracker());
+    return _arena.make_ptr<ast::ErrorExpr>(tracker());
 }
 
 // Types ---------------------------------------------------------------------------
@@ -1047,7 +1047,7 @@ Ptr<ast::Type> Parser::parse_named_type() {
 Ptr<ast::PrimType> Parser::parse_prim_type(ast::PrimType::Tag tag) {
     Tracker tracker(this);
     next();
-    return make_ptr<ast::PrimType>(tracker(), tag);
+    return _arena.make_ptr<ast::PrimType>(tracker(), tag);
 }
 
 Ptr<ast::Type> Parser::parse_tuple_type() {
@@ -1061,7 +1061,7 @@ Ptr<ast::Type> Parser::parse_tuple_type() {
         args[0]->loc = tracker();
         return std::move(args[0]);
     }
-    return make_ptr<ast::TupleType>(tracker(), std::move(args));
+    return _arena.make_ptr<ast::TupleType>(tracker(), std::move(args));
 }
 
 Ptr<ast::ArrayType> Parser::parse_array_type() {
@@ -1074,11 +1074,11 @@ Ptr<ast::ArrayType> Parser::parse_array_type() {
         auto size = parse_array_size();
         expect(Token::RBracket);
         if (size)
-            return make_ptr<ast::SizedArrayType>(tracker(), std::move(elem), std::move(*size), is_simd);
-        return make_ptr<ast::UnsizedArrayType>(tracker(), std::move(elem));
+            return _arena.make_ptr<ast::SizedArrayType>(tracker(), std::move(elem), std::move(*size), is_simd);
+        return _arena.make_ptr<ast::UnsizedArrayType>(tracker(), std::move(elem));
     } else {
         expect(Token::RBracket);
-        return make_ptr<ast::UnsizedArrayType>(tracker(), std::move(elem));
+        return _arena.make_ptr<ast::UnsizedArrayType>(tracker(), std::move(elem));
     }
 }
 
@@ -1093,10 +1093,10 @@ Ptr<ast::FnType> Parser::parse_fn_type() {
     expect(Token::Arrow);
     Ptr<ast::Type> to;
     if (accept(Token::Not))
-        to = make_ptr<ast::NoCodomType>(prev_);
+        to = _arena.make_ptr<ast::NoCodomType>(prev_);
     else
         to = parse_type();
-    return make_ptr<ast::FnType>(tracker(), std::move(from), std::move(to));
+    return _arena.make_ptr<ast::FnType>(tracker(), std::move(from), std::move(to));
 }
 
 Ptr<ast::PtrType> Parser::parse_ptr_type() {
@@ -1110,23 +1110,23 @@ Ptr<ast::PtrType> Parser::parse_ptr_type() {
     if (ahead().tag() == Token::AddrSpace)
         addr_space = parse_addr_space();
     auto pointee = parse_type();
-    auto inner_ptr = make_ptr<ast::PtrType>(tracker(), std::move(pointee), is_mut, addr_space);
+    auto inner_ptr = _arena.make_ptr<ast::PtrType>(tracker(), std::move(pointee), is_mut, addr_space);
     return double_ptr
-        ? make_ptr<ast::PtrType>(tracker(), std::move(inner_ptr), false, 0)
+        ? _arena.make_ptr<ast::PtrType>(tracker(), std::move(inner_ptr), false, 0)
         : std::move(inner_ptr);
 }
 
 Ptr<ast::TypeApp> Parser::parse_type_app() {
     Tracker tracker(this);
     auto path = parse_path();
-    return make_ptr<ast::TypeApp>(tracker(), std::move(path));
+    return _arena.make_ptr<ast::TypeApp>(tracker(), std::move(path));
 }
 
 Ptr<ast::ErrorType> Parser::parse_error_type() {
     Tracker tracker(this);
     error(ahead().loc(), "expected type, got '{}'", ahead().string());
     next();
-    return make_ptr<ast::ErrorType>(tracker());
+    return _arena.make_ptr<ast::ErrorType>(tracker());
 }
 
 Ptr<ast::Filter> Parser::parse_filter() {
@@ -1137,7 +1137,7 @@ Ptr<ast::Filter> Parser::parse_filter() {
         expr = parse_expr();
         expect(Token::RParen);
     }
-    return make_ptr<ast::Filter>(tracker(), std::move(expr));
+    return _arena.make_ptr<ast::Filter>(tracker(), std::move(expr));
 }
 
 Ptr<ast::AttrList> Parser::parse_attr_list() {
@@ -1148,7 +1148,7 @@ Ptr<ast::AttrList> Parser::parse_attr_list() {
     parse_list(Token::RBracket, Token::Comma, [&] {
         attrs.emplace_back(parse_attr());
     });
-    return make_ptr<ast::AttrList>(tracker(), std::move(attrs));
+    return _arena.make_ptr<ast::AttrList>(tracker(), std::move(attrs));
 }
 
 Ptr<ast::Attr> Parser::parse_attr() {
@@ -1162,13 +1162,13 @@ Ptr<ast::Attr> Parser::parse_attr() {
         if (ahead().tag() == Token::Lit) {
             auto lit = ahead().literal();
             eat(Token::Lit);
-            return make_ptr<ast::LiteralAttr>(tracker(), std::move(name), lit);
+            return _arena.make_ptr<ast::LiteralAttr>(tracker(), std::move(name), lit);
         } else if (ahead().tag() == Token::Id) {
             auto path = parse_path();
-            return make_ptr<ast::PathAttr>(tracker(), std::move(name), std::move(path));
+            return _arena.make_ptr<ast::PathAttr>(tracker(), std::move(name), std::move(path));
         } else {
             error(ahead().loc(), "expected attribute value, got '{}'", ahead().string());
-            return make_ptr<ast::NamedAttr>(tracker(), std::move(name), PtrVector<ast::Attr>());
+            return _arena.make_ptr<ast::NamedAttr>(tracker(), std::move(name), PtrVector<ast::Attr>());
         }
     } else {
         PtrVector<ast::Attr> args;
@@ -1177,7 +1177,7 @@ Ptr<ast::Attr> Parser::parse_attr() {
                 args.emplace_back(parse_attr());
             });
         }
-        return make_ptr<ast::NamedAttr>(tracker(), std::move(name), std::move(args));
+        return _arena.make_ptr<ast::NamedAttr>(tracker(), std::move(name), std::move(args));
     }
 }
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -782,7 +782,7 @@ Ptr<ast::Expr> Parser::parse_for_expr() {
 
     auto expr = parse_expr();
     auto call_loc = expr->loc;
-    Ptr<ast::CallExpr> call(expr->isa<ast::CallExpr>() ? expr.release()->as<ast::CallExpr>() : nullptr);
+    Ptr<ast::CallExpr> call(expr->isa<ast::CallExpr>() ? expr->as<ast::CallExpr>() : nullptr);
     if (!call) {
         error(ahead().loc(), "invalid for loop expression");
         return make_ptr<ast::ErrorExpr>(tracker());
@@ -798,7 +798,7 @@ Ptr<ast::Expr> Parser::parse_for_expr() {
     // Cannot use body->loc directly because std::move(body) might be executed first
     auto lambda = make_ptr<ast::FnExpr>(lambda_loc, nullptr, std::move(ptrn), nullptr, std::move(body));
 
-    Ptr<ast::Expr> callee(call->callee.release());
+    Ptr<ast::Expr> callee(call->callee.get());
     call->callee = make_ptr<ast::CallExpr>(call_loc, std::move(callee), std::move(lambda));
     return make_ptr<ast::ForExpr>(tracker(), std::move(call));
 }

--- a/src/summoner.cpp
+++ b/src/summoner.cpp
@@ -220,7 +220,7 @@ void IdPtrn::resolve_summons(artic::Summoner& summoner) {
 }
 
 void ImplicitParamPtrn::resolve_summons(artic::Summoner& summoner) {
-    summoner.insert(underlying->type, underlying->to_expr());
+    summoner.insert(underlying->type, underlying->to_expr(summoner._arena));
 }
 
 void FieldPtrn::resolve_summons(artic::Summoner& summoner) {


### PR DESCRIPTION
This PR replaces `unique_ptr` usage in the AST with `arena_ptr`, a like-behaved alternative backed by an arena.

This solves difficulties with the unique ownership model, for example allowing an expression to be used in two places without requiring deep copies, or having to risk lifetime issues with weak references.

The main entry point was modified so that the arena owns every node, including the top-level `ModDecl`. Additionally, the `TypeTable` was lifted out as well, fixing crashes when printing the AST after a failed implicit substitution.