### PR TITLE
Allow the definition of external types in artic.

### DIFF
--- a/include/artic/ast.h
+++ b/include/artic/ast.h
@@ -1506,6 +1506,28 @@ struct TypeDecl : public NamedDecl {
     void print(Printer&) const override;
 };
 
+struct ExtTypeDecl : public NamedDecl {
+    Ptr<TypeParamList> type_params;
+    PtrVector<std::string> type_args;
+
+    ExtTypeDecl(
+        const Loc& loc,
+        Identifier&& id,
+        Ptr<TypeParamList>&& type_params,
+        PtrVector<std::string>&& type_args)
+        : NamedDecl(loc, std::move(id))
+        , type_params(std::move(type_params))
+        , type_args(std::move(type_args))
+    {}
+
+    const thorin::Def* emit(Emitter&) const override;
+    const artic::Type* infer(TypeChecker&) override;
+    void bind_head(NameBinder&) override;
+    void bind(NameBinder&) override;
+    void resolve_summons(Summoner&) override {};
+    void print(Printer&) const override;
+};
+
 /// Module definition.
 struct ModDecl : public NamedDecl {
     PtrVector<Decl> decls;

--- a/include/artic/ast.h
+++ b/include/artic/ast.h
@@ -1508,17 +1508,20 @@ struct TypeDecl : public NamedDecl {
 
 struct ExtTypeDecl : public NamedDecl {
     Ptr<TypeParamList> type_params;
-    PtrVector<std::string> type_args;
+    std::string type_name;
+    std::vector<std::variant<Ptr<Type>, Ptr<Expr>>> args_;
 
     ExtTypeDecl(
         const Loc& loc,
         Identifier&& id,
+        std::string&& type_name,
         Ptr<TypeParamList>&& type_params,
-        PtrVector<std::string>&& type_args)
+        std::vector<std::variant<Ptr<Type>, Ptr<Expr>>>&& args)
         : NamedDecl(loc, std::move(id))
+        , type_name(type_name)
         , type_params(std::move(type_params))
-        , type_args(std::move(type_args))
-    {}
+        , args_(std::move(args)) {
+    }
 
     const thorin::Def* emit(Emitter&) const override;
     const artic::Type* infer(TypeChecker&) override;

--- a/include/artic/ast.h
+++ b/include/artic/ast.h
@@ -1510,6 +1510,7 @@ struct ExtTypeDecl : public NamedDecl {
     Ptr<TypeParamList> type_params;
     std::string type_name;
     std::vector<std::variant<Ptr<Type>, Ptr<Expr>>> args_;
+    std::vector<const artic::Type*> args_types_;
 
     ExtTypeDecl(
         const Loc& loc,

--- a/include/artic/parser.h
+++ b/include/artic/parser.h
@@ -34,6 +34,7 @@ private:
     Ptr<ast::ImplicitDecl>  parse_implicit_decl();
     Ptr<ast::StaticDecl>    parse_static_decl();
     Ptr<ast::TypeDecl>      parse_type_decl();
+    Ptr<ast::ExtTypeDecl>   parse_ext_type_decl();
     Ptr<ast::TypeParam>     parse_type_param();
     Ptr<ast::TypeParamList> parse_type_params();
     Ptr<ast::ModDecl>       parse_mod_decl();

--- a/include/artic/token.h
+++ b/include/artic/token.h
@@ -29,6 +29,7 @@ namespace artic {
     f(Struct, "struct") \
     f(Enum, "enum") \
     f(Type, "type") \
+    f(TypeExt, "type_ext") \
     f(Static, "static") \
     f(Implicit, "implicit") \
     f(Summon, "summon") \

--- a/include/artic/types.h
+++ b/include/artic/types.h
@@ -590,7 +590,10 @@ private:
         : PolyTypeFromDecl(type_table, decl)
     {}
 
-    const thorin::Type* convert(Emitter&) const override;
+    using UserType::convert;
+    const thorin::Type* convert(Emitter&, const Type*) const override;
+
+    std::string stringify(Emitter&) const override;
 
     friend class TypeTable;
 };

--- a/include/artic/types.h
+++ b/include/artic/types.h
@@ -582,6 +582,19 @@ private:
     friend class TypeTable;
 };
 
+struct ExtType : public PolyTypeFromDecl<UserType, ast::ExtTypeDecl> {
+    void print(Printer&) const override;
+
+private:
+    ExtType(TypeTable& type_table, const ast::ExtTypeDecl& decl)
+        : PolyTypeFromDecl(type_table, decl)
+    {}
+
+    const thorin::Type* convert(Emitter&) const override;
+
+    friend class TypeTable;
+};
+
 /// An application of a complex type with polymorphic parameters.
 struct TypeApp : public Type {
     const UserType* applied;
@@ -684,6 +697,7 @@ public:
     const EnumType*          enum_type(const ast::EnumDecl&);
     const ModType*           mod_type(const ast::ModDecl&);
     const TypeAlias*         type_alias(const ast::TypeDecl&);
+    const ExtType*           ext_type(const ast::ExtTypeDecl&);
 
     /// Creates a type application for structures/enumeration types,
     /// or returns the type alias expanded with the given type arguments.

--- a/include/artic/types.h
+++ b/include/artic/types.h
@@ -583,11 +583,13 @@ private:
 };
 
 struct ExtType : public PolyTypeFromDecl<UserType, ast::ExtTypeDecl> {
+    std::vector<const Type*> args_;
     void print(Printer&) const override;
 
 private:
-    ExtType(TypeTable& type_table, const ast::ExtTypeDecl& decl)
+    ExtType(TypeTable& type_table, const ast::ExtTypeDecl& decl, std::vector<const Type*>&& args)
         : PolyTypeFromDecl(type_table, decl)
+        , args_(std::move(args))
     {}
 
     using UserType::convert;
@@ -700,7 +702,7 @@ public:
     const EnumType*          enum_type(const ast::EnumDecl&);
     const ModType*           mod_type(const ast::ModDecl&);
     const TypeAlias*         type_alias(const ast::TypeDecl&);
-    const ExtType*           ext_type(const ast::ExtTypeDecl&);
+    const ExtType*           ext_type(const ast::ExtTypeDecl&, std::vector<const Type*>&&);
 
     /// Creates a type application for structures/enumeration types,
     /// or returns the type alias expanded with the given type arguments.

--- a/include/artic/types.h
+++ b/include/artic/types.h
@@ -583,13 +583,11 @@ private:
 };
 
 struct ExtType : public PolyTypeFromDecl<UserType, ast::ExtTypeDecl> {
-    std::vector<const Type*> args_;
     void print(Printer&) const override;
 
 private:
-    ExtType(TypeTable& type_table, const ast::ExtTypeDecl& decl, std::vector<const Type*>&& args)
+    ExtType(TypeTable& type_table, const ast::ExtTypeDecl& decl)
         : PolyTypeFromDecl(type_table, decl)
-        , args_(std::move(args))
     {}
 
     using UserType::convert;
@@ -702,7 +700,7 @@ public:
     const EnumType*          enum_type(const ast::EnumDecl&);
     const ModType*           mod_type(const ast::ModDecl&);
     const TypeAlias*         type_alias(const ast::TypeDecl&);
-    const ExtType*           ext_type(const ast::ExtTypeDecl&, std::vector<const Type*>&&);
+    const ExtType*           ext_type(const ast::ExtTypeDecl&);
 
     /// Creates a type application for structures/enumeration types,
     /// or returns the type alias expanded with the given type arguments.

--- a/src/bind.cpp
+++ b/src/bind.cpp
@@ -509,10 +509,20 @@ void TypeDecl::bind_head(NameBinder& binder) {
     binder.insert_symbol(*this);
 }
 
+void ExtTypeDecl::bind_head(NameBinder& binder) {
+    binder.insert_symbol(*this);
+}
+
 void TypeDecl::bind(NameBinder& binder) {
     binder.push_scope();
     if (type_params) binder.bind(*type_params);
     binder.bind(*aliased_type);
+    binder.pop_scope();
+}
+
+void ExtTypeDecl::bind(NameBinder& binder) {
+    binder.push_scope();
+    if (type_params) binder.bind(*type_params);
     binder.pop_scope();
 }
 

--- a/src/bind.cpp
+++ b/src/bind.cpp
@@ -522,7 +522,15 @@ void TypeDecl::bind(NameBinder& binder) {
 
 void ExtTypeDecl::bind(NameBinder& binder) {
     binder.push_scope();
-    if (type_params) binder.bind(*type_params);
+    //if (type_params) binder.bind(*type_params);
+    for (auto& arg : args_) {
+        if (auto t = std::get_if<Ptr<Type>>(&arg))
+            binder.bind(**t);
+        else if (auto e = std::get_if<Ptr<Expr>>(&arg))
+            binder.bind(**e);
+        else
+            assert(false);
+    }
     binder.pop_scope();
 }
 

--- a/src/check.cpp
+++ b/src/check.cpp
@@ -1816,6 +1816,11 @@ const artic::Type* TypeDecl::infer(TypeChecker& checker) {
     return type;
 }
 
+const artic::Type* ExtTypeDecl::infer(TypeChecker& checker) {
+    const artic::Type* type = checker.type_table.ext_type(*this);
+    return type;
+}
+
 const artic::Type* ModDecl::infer(TypeChecker& checker) {
     for (auto& decl : decls)
         checker.infer(*decl);

--- a/src/check.cpp
+++ b/src/check.cpp
@@ -1817,18 +1817,22 @@ const artic::Type* TypeDecl::infer(TypeChecker& checker) {
 }
 
 const artic::Type* ExtTypeDecl::infer(TypeChecker& checker) {
-    std::vector<const artic::Type*> args;
+    if (!checker.enter_decl(this))
+        return checker.type_table.type_error();
+    const ExtType* ext_type = checker.type_table.ext_type(*this);
+    // Set the type before entering the args
+    type = ext_type;
     for (auto& arg : args_) {
         if (auto t = std::get_if<Ptr<Type>>(&arg))
-            args.emplace_back(checker.infer(**t));
+            args_types_.emplace_back(checker.infer(**t));
         else if (auto e = std::get_if<Ptr<Expr>>(&arg)) {
             checker.infer(**e);
-            args.emplace_back(nullptr);
+            args_types_.emplace_back(nullptr);
         } else
             assert(false);
     }
-    const artic::Type* type = checker.type_table.ext_type(*this, std::move(args));
-    return type;
+    checker.exit_decl(this);
+    return ext_type;
 }
 
 const artic::Type* ModDecl::infer(TypeChecker& checker) {

--- a/src/check.cpp
+++ b/src/check.cpp
@@ -1827,6 +1827,8 @@ const artic::Type* ExtTypeDecl::infer(TypeChecker& checker) {
             args_types_.emplace_back(checker.infer(**t));
         else if (auto e = std::get_if<Ptr<Expr>>(&arg)) {
             checker.infer(**e);
+            if (!(*e)->is_constant())
+                checker.error((*e)->loc, "only constants are allowed as external type members");
             args_types_.emplace_back(nullptr);
         } else
             assert(false);

--- a/src/check.cpp
+++ b/src/check.cpp
@@ -1817,7 +1817,17 @@ const artic::Type* TypeDecl::infer(TypeChecker& checker) {
 }
 
 const artic::Type* ExtTypeDecl::infer(TypeChecker& checker) {
-    const artic::Type* type = checker.type_table.ext_type(*this);
+    std::vector<const artic::Type*> args;
+    for (auto& arg : args_) {
+        if (auto t = std::get_if<Ptr<Type>>(&arg))
+            args.emplace_back(checker.infer(**t));
+        else if (auto e = std::get_if<Ptr<Expr>>(&arg)) {
+            checker.infer(**e);
+            args.emplace_back(nullptr);
+        } else
+            assert(false);
+    }
+    const artic::Type* type = checker.type_table.ext_type(*this, std::move(args));
     return type;
 }
 

--- a/src/emit.cpp
+++ b/src/emit.cpp
@@ -1746,6 +1746,10 @@ const thorin::Def* TypeDecl::emit(Emitter&) const {
     return nullptr;
 }
 
+const thorin::Def* ExtTypeDecl::emit(Emitter&) const {
+    return nullptr;
+}
+
 const thorin::Def* ModDecl::emit(Emitter& emitter) const {
     for (auto& decl : decls) {
         // Do not emit polymorphic functions directly: Those will be emitted from
@@ -1935,6 +1939,14 @@ const thorin::Type* UserType::convert(Emitter&, const Type*) const {
     // Should never be called
     assert(false);
     return nullptr;
+}
+
+const thorin::Type* ExtType::convert(Emitter& emitter) const {
+    std::vector<std::string> args;
+    for (auto& arg : decl.type_args) {
+        args.emplace_back(*arg);
+    }
+    return emitter.world.extern_type(decl.id.name, args);
 }
 
 inline std::string stringify_params(

--- a/src/emit.cpp
+++ b/src/emit.cpp
@@ -2056,7 +2056,9 @@ const thorin::Type* ExtType::convert(Emitter& emitter, const Type* parent) const
             assert(false);
     }
 
-    auto type = emitter.world.extern_type(decl.type_name, args);
+    auto type = emitter.world.extern_type(decl.type_name, args.size());
+    for (size_t i = 0; i < args.size(); i++)
+        type->set_op(i, args[i]);
     emitter.types[parent] = type;
     return type;
 }

--- a/src/emit.cpp
+++ b/src/emit.cpp
@@ -2056,7 +2056,7 @@ const thorin::Type* ExtType::convert(Emitter& emitter, const Type* parent) const
             assert(false);
     }
 
-    auto type = emitter.world.extern_type(decl.type_name, args.size());
+    auto type = emitter.world.extern_type(decl.type_name, args.size(), { decl.id.name });
     for (size_t i = 0; i < args.size(); i++)
         type->set_op(i, args[i]);
     emitter.types[parent] = type;

--- a/src/emit.cpp
+++ b/src/emit.cpp
@@ -2046,12 +2046,17 @@ const thorin::Type* ExtType::convert(Emitter& emitter, const Type* parent) const
     if (auto it = emitter.types.find(this); !type_params() && it != emitter.types.end())
         return it->second;
 
-    std::vector<std::string> args;
-    for (auto& arg : decl.type_args) {
-        args.emplace_back(*arg);
+    std::vector<const thorin::Def*> args;
+    for (size_t i = 0; i < args_.size(); i++) {
+        if (auto t = args_[i]) {
+            args.emplace_back(t->convert(emitter));
+        } else if (auto e = std::get_if<Ptr<ast::Expr>>(&decl.args_[i]))
+            args.emplace_back(emitter.emit(**e));
+        else
+            assert(false);
     }
 
-    auto type = emitter.world.extern_type(decl.id.name, args);
+    auto type = emitter.world.extern_type(decl.type_name, args);
     emitter.types[parent] = type;
     return type;
 }

--- a/src/emit.cpp
+++ b/src/emit.cpp
@@ -2046,20 +2046,18 @@ const thorin::Type* ExtType::convert(Emitter& emitter, const Type* parent) const
     if (auto it = emitter.types.find(this); !type_params() && it != emitter.types.end())
         return it->second;
 
-    std::vector<const thorin::Def*> args;
-    for (size_t i = 0; i < args_.size(); i++) {
-        if (auto t = args_[i]) {
-            args.emplace_back(t->convert(emitter));
+    auto type = emitter.world.extern_type(decl.type_name, decl.args_types_.size(), { decl.id.name });
+    emitter.types[parent] = type;
+
+    for (size_t i = 0; i < decl.args_types_.size(); i++) {
+        if (auto t = decl.args_types_[i]) {
+            type->set_op(i, t->convert(emitter));
         } else if (auto e = std::get_if<Ptr<ast::Expr>>(&decl.args_[i]))
-            args.emplace_back(emitter.emit(**e));
+            type->set_op(i, emitter.emit(**e));
         else
             assert(false);
     }
 
-    auto type = emitter.world.extern_type(decl.type_name, args.size(), { decl.id.name });
-    for (size_t i = 0; i < args.size(); i++)
-        type->set_op(i, args[i]);
-    emitter.types[parent] = type;
     return type;
 }
 

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -23,6 +23,7 @@ std::unordered_map<std::string, Token::Tag> Lexer::keywords{
     std::make_pair("struct",    Token::Struct),
     std::make_pair("enum",      Token::Enum),
     std::make_pair("type",      Token::Type),
+    std::make_pair("type_ext",  Token::TypeExt),
     std::make_pair("implicit",  Token::Implicit),
     std::make_pair("summon",    Token::Summon),
     std::make_pair("static",    Token::Static),

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -207,20 +207,22 @@ Ptr<ast::ExtTypeDecl> Parser::parse_ext_type_decl() {
     auto id = parse_id();
 
     Ptr<ast::TypeParamList> type_params;
-    if (ahead().tag() == Token::LBracket)
-        type_params = parse_type_params();
+    // if (ahead().tag() == Token::LBracket)
+    //     type_params = parse_type_params();
 
-    PtrVector<std::string> type_args;
-    if (accept(Token::Eq)) {
-        expect(Token::LBrace);
-
-        parse_list(Token::RBrace, Token::Comma, [&] {
-            type_args.emplace_back(make_ptr<std::string>(parse_str()));
-        });
-    }
+    std::vector<std::variant<Ptr<ast::Type>, Ptr<ast::Expr>>> args;
+    expect(Token::Eq);
+    auto type_name = parse_str();
+    expect(Token::LBrace);
+    parse_list(Token::RBrace, Token::Comma, [&] {
+        if (accept(Token::Type))
+            args.emplace_back(parse_type());
+        else
+            args.emplace_back(parse_expr());
+    });
 
     expect(Token::Semi);
-    return make_ptr<ast::ExtTypeDecl>(tracker(), std::move(id), std::move(type_params), std::move(type_args));
+    return make_ptr<ast::ExtTypeDecl>(tracker(), std::move(id), std::move(type_name), std::move(type_params), std::move(args));
 }
 
 Ptr<ast::ImplicitDecl> Parser::parse_implicit_decl() {

--- a/src/print.cpp
+++ b/src/print.cpp
@@ -614,6 +614,17 @@ void TypeDecl::print(Printer& p) const {
     p << ';';
 }
 
+void ExtTypeDecl::print(Printer& p) const {
+    if (attrs) attrs->print(p);
+    p << log::keyword_style("type_ext") << ' ' <<  id.name;
+    if (type_params) type_params->print(p);
+    p << " = { ";
+    print_list(p, ',', type_args, [&] (auto& arg) {
+        p << *arg;
+    });
+    p << " };";
+}
+
 void ModDecl::print(Printer& p) const {
     if (attrs) attrs->print(p);
     bool anon = id.name == "";
@@ -822,6 +833,10 @@ void ModType::print(Printer& p) const {
 }
 
 void TypeAlias::print(Printer& p) const {
+    p << decl.id.name;
+}
+
+void ExtType::print(Printer& p) const {
     p << decl.id.name;
 }
 

--- a/src/print.cpp
+++ b/src/print.cpp
@@ -617,10 +617,15 @@ void TypeDecl::print(Printer& p) const {
 void ExtTypeDecl::print(Printer& p) const {
     if (attrs) attrs->print(p);
     p << log::keyword_style("type_ext") << ' ' <<  id.name;
-    if (type_params) type_params->print(p);
-    p << " = { ";
-    print_list(p, ',', type_args, [&] (auto& arg) {
-        p << *arg;
+    // if (type_params) type_params->print(p);
+    p << " = \"" << type_name << "\" { ";
+    print_list(p, ',', args_, [&] (auto& arg) {
+        if (auto t = std::get_if<Ptr<ast::Type>>(&arg)) {
+            p << **t;
+        } else if (auto e = std::get_if<Ptr<ast::Expr>>(&arg))
+            p << **e;
+        else
+            p << "invalid";
     });
     p << " };";
 }

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -726,6 +726,10 @@ const TypeAlias* TypeTable::type_alias(const ast::TypeDecl& decl) {
     return insert<TypeAlias>(decl);
 }
 
+const ExtType* TypeTable::ext_type(const ast::ExtTypeDecl& decl) {
+    return insert<ExtType>(decl);
+}
+
 const Type* TypeTable::type_app(const UserType* applied, const ArrayRef<const Type*>& type_args) {
     if (auto type_alias = applied->isa<TypeAlias>()) {
         assert(type_alias->type_params() && type_alias->decl.aliased_type->type);

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -726,8 +726,8 @@ const TypeAlias* TypeTable::type_alias(const ast::TypeDecl& decl) {
     return insert<TypeAlias>(decl);
 }
 
-const ExtType* TypeTable::ext_type(const ast::ExtTypeDecl& decl) {
-    return insert<ExtType>(decl);
+const ExtType* TypeTable::ext_type(const ast::ExtTypeDecl& decl, std::vector<const Type*>&& args) {
+    return insert<ExtType>(decl, std::move(args));
 }
 
 const Type* TypeTable::type_app(const UserType* applied, const ArrayRef<const Type*>& type_args) {

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -726,8 +726,8 @@ const TypeAlias* TypeTable::type_alias(const ast::TypeDecl& decl) {
     return insert<TypeAlias>(decl);
 }
 
-const ExtType* TypeTable::ext_type(const ast::ExtTypeDecl& decl, std::vector<const Type*>&& args) {
-    return insert<ExtType>(decl, std::move(args));
+const ExtType* TypeTable::ext_type(const ast::ExtTypeDecl& decl) {
+    return insert<ExtType>(decl);
 }
 
 const Type* TypeTable::type_app(const UserType* applied, const ArrayRef<const Type*>& type_args) {


### PR DESCRIPTION
Relates to https://github.com/AnyDSL/thorin/pull/183.

The syntax for these external types is `type_ext <NAME>   = { <Options> };`, with `<Options>` being a List of string literals. Back-end support is required for these types to work; and the back-end will define how the type is being interpreted.