### PR TITLE
Improve error handling on invalid code / upstream artic changes from language server development

### DIFF
--- a/include/artic/ast.h
+++ b/include/artic/ast.h
@@ -185,7 +185,7 @@ struct Path : public Node {
     // Set during name-binding, corresponds to the declaration that
     // is associated with the _first_ element of the path.
     // The rest of the path is resolved during type-checking.
-    ast::NamedDecl* start_decl;
+    ast::NamedDecl* start_decl = nullptr;
 
     // Set during type-checking
     bool is_value = false;

--- a/include/artic/ast.h
+++ b/include/artic/ast.h
@@ -434,6 +434,7 @@ struct ErrorType : public Type {
     {}
 
     void bind(NameBinder&) override;
+    const artic::Type* infer(TypeChecker&) override;
     void print(Printer&) const override;
 };
 
@@ -1203,6 +1204,7 @@ struct ErrorExpr : public Expr {
     {}
 
     void bind(NameBinder&) override;
+    const artic::Type* infer(TypeChecker&) override;
     void resolve_summons(Summoner&) override {};
     void print(Printer&) const override;
 };
@@ -1555,6 +1557,7 @@ struct ErrorDecl : public Decl {
     ErrorDecl(const Loc& loc) : Decl(loc) {}
 
     void bind(NameBinder&) override;
+    const artic::Type* infer(TypeChecker&) override;
     void resolve_summons(Summoner&) override {};
     void print(Printer&) const override;
 };
@@ -1752,6 +1755,7 @@ struct ErrorPtrn : public Ptrn {
     bool is_trivial() const override;
 
     void bind(NameBinder&) override;
+    const artic::Type* infer(TypeChecker&) override;
     void resolve_summons(Summoner&) override {};
     void print(Printer&) const override;
 };

--- a/include/artic/bind.h
+++ b/include/artic/bind.h
@@ -40,7 +40,7 @@ public:
     void bind(ast::Node&);
 
     void push_scope(bool top_level = false) { scopes_.emplace_back(top_level); }
-    void pop_scope();
+    void pop_scope(bool report_unused = true);
     void insert_symbol(ast::NamedDecl&, const std::string&);
     void insert_symbol(ast::NamedDecl& decl) {
         insert_symbol(decl, decl.id.name);

--- a/include/artic/check.h
+++ b/include/artic/check.h
@@ -42,6 +42,7 @@ public:
     const Type* bad_arguments(const Loc&, const std::string_view&, size_t, size_t);
     const Type* invalid_cast(const Loc&, const Type*, const Type*);
     const Type* invalid_simd(const Loc&, const Type*);
+    const Type* invalid_array_size(const Loc&);
     void invalid_ptrn(const Loc&, bool);
     void invalid_constraint(const Loc&, const TypeVar*, const Type*, const Type*, const Type*);
     void invalid_attr(const Loc&, const std::string_view&);

--- a/include/artic/loc.h
+++ b/include/artic/loc.h
@@ -25,7 +25,7 @@ struct Loc {
     }
     bool operator != (const Loc& loc) const { return !(*this == loc); }
 
-    Loc() = default;
+    Loc() : Loc(nullptr, 0, 0) {}
     Loc(std::shared_ptr<std::string> file, int row, int col)
         : Loc(file, { row, col })
     {}

--- a/include/artic/log.h
+++ b/include/artic/log.h
@@ -171,7 +171,7 @@ template <typename... Args>
 void error(const char* fmt, Args&&... args) {
     log::format(err, "{}: ", error_style("error"));
     log::format(err, fmt, std::forward<Args>(args)...);
-    out.stream << std::endl;
+    err.stream << std::endl;
 }
 
 } // namespace log

--- a/include/artic/parser.h
+++ b/include/artic/parser.h
@@ -40,6 +40,13 @@ private:
     Ptr<ast::UseDecl>       parse_use_decl();
     Ptr<ast::ErrorDecl>     parse_error_decl();
 
+    /// Whether `tag` can begin a declaration, and is therefore a safe place to resume
+    /// parsing after one has gone wrong.
+    static bool begins_decl(Token::Tag);
+    /// Skips tokens until the next declaration can be parsed. Braces are counted so a
+    /// declaration nested in the body being skipped does not end the skip early.
+    void skip_to_decl();
+
     Ptr<ast::Ptrn>          parse_ptrn(bool = false, bool = false);
     Ptr<ast::Ptrn>          parse_typed_ptrn(Ptr<ast::Ptrn>&&);
     Ptr<ast::IdPtrn>        parse_id_ptrn(ast::Identifier&&, bool);
@@ -148,6 +155,16 @@ private:
         parse_list(std::array<Token::Tag, 1>{end}, std::array<Token::Tag, 1>{sep}, f);
     }
 
+    /// Whether a parse error has already been reported about the token at `loc`. The
+    /// recovery path re-reports whatever `expect()` has just complained about, and two
+    /// messages on the same token say nothing the first one did not.
+    bool reported_at(const Loc& loc) {
+        if (last_error_.row == loc.begin.row && last_error_.col == loc.begin.col)
+            return true;
+        last_error_ = loc.begin;
+        return false;
+    }
+
     template <size_t N>
     size_t expect(std::array<Token::Tag, N> tags) {
         if (N == 1) {
@@ -160,22 +177,28 @@ private:
                     tag_list += '\'' + Token::tag_to_string(tags[i]) + '\'';
                     if (i != N - 1) tag_list += " or ";
                 }
-                error(ahead().loc(), "expected {}, got '{}'", tag_list, ahead().string());
-            }
-            next();
+                if (!reported_at(ahead().loc()))
+                    error(ahead().loc(), "expected {}, got '{}'", tag_list, ahead().string());
+            } else
+                next();
             return std::distance(it, tags.begin());
         }
     }
 
+    /// Consumes `tag`, or reports it missing. A token that is *not* what was expected is
+    /// left in place: it is usually the one that resynchronises the parse -- typically the
+    /// `fn` opening the next declaration -- and eating it turns one mistake into an error
+    /// per token until the end of the file.
     bool expect(Token::Tag tag) {
-        bool res = ahead().tag() == tag;
-        if (!res) {
+        if (ahead().tag() == tag) {
+            next();
+            return true;
+        }
+        if (!reported_at(ahead().loc()))
             error(ahead().loc(), "expected '{}', got '{}'",
                 Token::tag_to_string(tag),
                 ahead().string());
-        }
-        next();
-        return res;
+        return false;
     }
 
     void eat(Token::Tag tag) {
@@ -208,6 +231,7 @@ private:
     Token ahead_[max_ahead];
     Lexer& lexer_;
     Loc prev_;
+    Loc::Pos last_error_ = { -1, -1 };
     Arena& _arena;
 };
 

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -448,7 +448,8 @@ bool BlockExpr::has_side_effect() const {
 }
 
 bool CallExpr::is_jumping() const {
-    assert(type);
+    // A call can reach this without a type when an earlier stage failed, e.g. `let a = return(;`.
+    if (!type) return false;
     return type->isa<artic::NoRetType>();
 }
 

--- a/src/bind.cpp
+++ b/src/bind.cpp
@@ -34,7 +34,9 @@ void NameBinder::pop_scope() {
 
 void NameBinder::insert_symbol(ast::NamedDecl& decl, const std::string& name) {
     assert(!scopes_.empty());
-    assert(!name.empty());
+
+    // A declaration the parser could not finish has no identifier to bind.
+    if (name.empty()) return;
 
     // Do not bind anonymous variables
     if (name[0] == '_') return;

--- a/src/bind.cpp
+++ b/src/bind.cpp
@@ -18,15 +18,17 @@ void NameBinder::bind(ast::Node& node) {
     node.bind(*this);
 }
 
-void NameBinder::pop_scope() {
-    for (auto& pair : scopes_.back().symbols) {
-        auto decl = pair.second.decl;
-        if (pair.second.use_count == 0 &&
-            !scopes_.back().top_level &&
-            !decl->isa<ast::FieldDecl>() &&
-            !decl->isa<ast::OptionDecl>()) {
-            warn(decl->loc, "unused identifier '{}'", pair.first);
-            note("prefix unused identifiers with '_'");
+void NameBinder::pop_scope(bool report_unused) {
+    if (report_unused) {
+        for (auto& pair : scopes_.back().symbols) {
+            auto decl = pair.second.decl;
+            if (pair.second.use_count == 0 &&
+                !scopes_.back().top_level &&
+                !decl->isa<ast::FieldDecl>() &&
+                !decl->isa<ast::OptionDecl>()) {
+                warn(decl->loc, "unused identifier '{}'", pair.first);
+                note("prefix unused identifiers with '_'");
+            }
         }
     }
     scopes_.pop_back();
@@ -464,7 +466,8 @@ void FnDecl::bind(NameBinder& binder) {
         if (fn->ret_type)
             binder.bind(*fn->ret_type);
     }
-    binder.pop_scope();
+    // A prototype binds its parameters without ever having a body to use them in.
+    binder.pop_scope(fn->body.get() != nullptr);
 }
 
 void FieldDecl::bind(NameBinder& binder) {

--- a/src/check.cpp
+++ b/src/check.cpp
@@ -618,6 +618,14 @@ const artic::Type* Node::infer(TypeChecker& checker) {
     return checker.cannot_infer(loc, "expression");
 }
 
+// A node the parser gave up on. It carries the error type rather than no type at all, so
+// `should_report_error()` silences everything downstream that touches it: the parse error
+// has already been reported, and "cannot infer type for expression" adds nothing to it.
+const artic::Type* ErrorType::infer(TypeChecker& checker) { return checker.type_table.type_error(); }
+const artic::Type* ErrorExpr::infer(TypeChecker& checker) { return checker.type_table.type_error(); }
+const artic::Type* ErrorDecl::infer(TypeChecker& checker) { return checker.type_table.type_error(); }
+const artic::Type* ErrorPtrn::infer(TypeChecker& checker) { return checker.type_table.type_error(); }
+
 const artic::Type* Ptrn::check(TypeChecker& checker, const artic::Type* expected) {
     // Patterns use the inverted subtype relation: In this case, the expected type
     // is assumed to be the type of the expression bound by the pattern, and thus

--- a/src/check.cpp
+++ b/src/check.cpp
@@ -87,6 +87,12 @@ const Type* TypeChecker::invalid_simd(const Loc& loc, const Type* elem_type) {
     return type_table.type_error();
 }
 
+const Type* TypeChecker::invalid_array_size(const Loc& loc) {
+    error(loc, "expected an immutable {} declaration with an initializer as array size",
+        log::keyword_style("static"));
+    return type_table.type_error();
+}
+
 void TypeChecker::invalid_ptrn(const Loc& loc, bool must_be_trivial) {
     if (must_be_trivial) {
         error(loc, "irrefutable (always matching) pattern expected");
@@ -869,18 +875,19 @@ const artic::Type* SizedArrayType::infer(TypeChecker& checker) {
                 decl = &mod_type->member(path.elems[i + 1].index);
             } else if (!path.is_ctor) {
                 assert(path.elems[i].inferred_args.empty());
-                assert(decl->isa<StaticDecl>() && "The only supported type right now.");
+                if (!decl->isa<StaticDecl>())
+                    return checker.invalid_array_size(path.loc);
                 break;
             } else if (match_app<StructType>(path.elems[i].type).second) {
-                assert(false && "This is not supported as a size for repeated arrays.");
+                return checker.invalid_array_size(path.loc);
             } else if (auto [type_app, enum_type] = match_app<artic::EnumType>(path.elems[i].type); enum_type) {
-                assert(false && "This is not supported as a size for repeated arrays.");
+                return checker.invalid_array_size(path.loc);
             }
         }
 
-        auto static_decl = decl->as<StaticDecl>();
-        assert(!static_decl->is_mut);
-        assert(static_decl->init);
+        auto static_decl = decl->isa<StaticDecl>();
+        if (!static_decl || static_decl->is_mut || !static_decl->init)
+            return checker.invalid_array_size(path.loc);
         auto& value = static_decl->init;
         auto lit_value = value->as<LiteralExpr>()->lit;
 
@@ -1044,18 +1051,19 @@ const artic::Type* RepeatArrayExpr::infer(TypeChecker& checker) {
                 decl = &mod_type->member(path.elems[i + 1].index);
             } else if (!path.is_ctor) {
                 assert(path.elems[i].inferred_args.empty());
-                assert(decl->isa<StaticDecl>() && "The only supported type right now.");
+                if (!decl->isa<StaticDecl>())
+                    return checker.invalid_array_size(path.loc);
                 break;
             } else if (match_app<StructType>(path.elems[i].type).second) {
-                assert(false && "This is not supported as a size for repeated arrays.");
+                return checker.invalid_array_size(path.loc);
             } else if (auto [type_app, enum_type] = match_app<artic::EnumType>(path.elems[i].type); enum_type) {
-                assert(false && "This is not supported as a size for repeated arrays.");
+                return checker.invalid_array_size(path.loc);
             }
         }
 
-        auto static_decl = decl->as<StaticDecl>();
-        assert(!static_decl->is_mut);
-        assert(static_decl->init);
+        auto static_decl = decl->isa<StaticDecl>();
+        if (!static_decl || static_decl->is_mut || !static_decl->init)
+            return checker.invalid_array_size(path.loc);
         auto& value = static_decl->init;
         auto lit_value = value->as<LiteralExpr>()->lit;
 
@@ -1077,18 +1085,19 @@ const artic::Type* RepeatArrayExpr::check(TypeChecker& checker, const artic::Typ
                 decl = &mod_type->member(path.elems[i + 1].index);
             } else if (!path.is_ctor) {
                 assert(path.elems[i].inferred_args.empty());
-                assert(decl->isa<StaticDecl>() && "The only supported type right now.");
+                if (!decl->isa<StaticDecl>())
+                    return checker.invalid_array_size(path.loc);
                 break;
             } else if (match_app<StructType>(path.elems[i].type).second) {
-                assert(false && "This is not supported as a size for repeated arrays.");
+                return checker.invalid_array_size(path.loc);
             } else if (auto [type_app, enum_type] = match_app<artic::EnumType>(path.elems[i].type); enum_type) {
-                assert(false && "This is not supported as a size for repeated arrays.");
+                return checker.invalid_array_size(path.loc);
             }
         }
 
-        auto static_decl = decl->as<StaticDecl>();
-        assert(!static_decl->is_mut);
-        assert(static_decl->init);
+        auto static_decl = decl->isa<StaticDecl>();
+        if (!static_decl || static_decl->is_mut || !static_decl->init)
+            return checker.invalid_array_size(path.loc);
         auto& value = static_decl->init;
         auto lit_value = value->as<LiteralExpr>()->lit;
 
@@ -1375,7 +1384,7 @@ const artic::Type* BreakExpr::infer(TypeChecker& checker) {
         if (!domain)
             return checker.cannot_infer(loc, "break expression");
     } else
-        assert(false);
+        return checker.cannot_infer(loc, "break expression");
     return checker.type_table.cn_type(domain);
 }
 
@@ -1395,7 +1404,7 @@ const artic::Type* ContinueExpr::infer(TypeChecker& checker) {
         if (!domain)
             return checker.cannot_infer(loc, "continue expression");
     } else
-        assert(false);
+        return checker.cannot_infer(loc, "continue expression");
     return checker.type_table.cn_type(domain);
 }
 

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -209,7 +209,9 @@ Token Lexer::next() {
 
         append();
         error(loc_, "unknown token '{}'", str_);
-        return Token(loc_);
+        // Keep lexing instead of returning an error token: a single stray character must not
+        // truncate the token stream, or every later stage sees a file that ends there.
+        continue;
     }
 }
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -81,8 +81,10 @@ Ptr<ast::FnDecl> Parser::parse_fn_decl() {
     Ptr<ast::Ptrn> param;
     if (ahead().tag() == Token::LParen)
         param = parse_tuple_ptrn(true, true);
-    else
+    else {
         error(ahead().loc(), "parameter list expected in function definition");
+        param = parse_error_ptrn();
+    }
 
     Ptr<ast::Type> ret_type;
     if (accept(Token::Arrow)) {
@@ -276,10 +278,50 @@ Ptr<ast::UseDecl> Parser::parse_use_decl() {
     return _arena.make_ptr<ast::UseDecl>(tracker(), std::move(path), std::move(id));
 }
 
+bool Parser::begins_decl(Token::Tag tag) {
+    switch (tag) {
+        case Token::Fn:
+        case Token::Struct:
+        case Token::Enum:
+        case Token::Type:
+        case Token::Mod:
+        case Token::Static:
+        case Token::Implicit:
+        case Token::Use:
+        case Token::Let:
+        case Token::Hash:
+            return true;
+        default:
+            return false;
+    }
+}
+
+void Parser::skip_to_decl() {
+    size_t depth = 0;
+    while (ahead().tag() != Token::End) {
+        auto tag = ahead().tag();
+        if (tag == Token::LBrace)
+            depth++;
+        else if (tag == Token::RBrace) {
+            // Not ours: it closes a block an enclosing parser is still inside.
+            if (depth == 0) return;
+            depth--;
+        } else if (depth == 0 && begins_decl(tag))
+            return;
+        next();
+    }
+}
+
 Ptr<ast::ErrorDecl> Parser::parse_error_decl() {
     Tracker tracker(this);
-    error(ahead().loc(), "expected declaration, got '{}'", ahead().string());
+    if (!reported_at(ahead().loc()))
+        error(ahead().loc(), "expected declaration, got '{}'", ahead().string());
+    // Panic-mode recovery. Skipping a single token re-reports on every token of whatever
+    // follows, so one broken declaration used to cost an error per token to the end of the
+    // file and every declaration after it was lost. Consume at least one so the caller's
+    // loop always makes progress.
     next();
+    skip_to_decl();
     return _arena.make_ptr<ast::ErrorDecl>(tracker());
 }
 
@@ -441,7 +483,8 @@ Ptr<ast::ArrayPtrn> Parser::parse_array_ptrn() {
 
 Ptr<ast::ErrorPtrn> Parser::parse_error_ptrn() {
     Tracker tracker(this);
-    error(ahead().loc(), "expected pattern, got '{}'", ahead().string());
+    if (!reported_at(ahead().loc()))
+        error(ahead().loc(), "expected pattern, got '{}'", ahead().string());
     next();
     return _arena.make_ptr<ast::ErrorPtrn>(tracker());
 }
@@ -1012,7 +1055,8 @@ done:
 
 Ptr<ast::ErrorExpr> Parser::parse_error_expr() {
     Tracker tracker(this);
-    error(ahead().loc(), "expected expression, got '{}'", ahead().string());
+    if (!reported_at(ahead().loc()))
+        error(ahead().loc(), "expected expression, got '{}'", ahead().string());
     next();
     return _arena.make_ptr<ast::ErrorExpr>(tracker());
 }
@@ -1124,7 +1168,8 @@ Ptr<ast::TypeApp> Parser::parse_type_app() {
 
 Ptr<ast::ErrorType> Parser::parse_error_type() {
     Tracker tracker(this);
-    error(ahead().loc(), "expected type, got '{}'", ahead().string());
+    if (!reported_at(ahead().loc()))
+        error(ahead().loc(), "expected type, got '{}'", ahead().string());
     next();
     return _arena.make_ptr<ast::ErrorType>(tracker());
 }

--- a/src/print.cpp
+++ b/src/print.cpp
@@ -193,7 +193,7 @@ void FnExpr::print(Printer& p) const {
         ret_type->print(p);
         p << ' ';
     }
-    body->print(p);
+    if (body) body->print(p);
 }
 
 void BlockExpr::print(Printer& p) const {
@@ -526,7 +526,7 @@ void FnDecl::print(Printer& p) const {
     p << id.name;
 
     if (type_params) type_params->print(p);
-    print_parens(p, fn->param);
+    if (fn->param) print_parens(p, fn->param);
 
     if (fn->ret_type) {
         p << " -> ";


### PR DESCRIPTION
Produce errors instead of crashing when processing invalid code. Also motivated by the requirement of the language server to run further compilation stages after parsing has failed.
Should not change behaviour on valid input.

Error handling improvements:
- lexer now keeps going when it reaches an error token, instead of ending the parse
- fixed some possible null pointer dereferences
- asserts reachable from ordinary source turned into diagnostics
- skip to next declaration instead of cascading errors: On a file whose first function is missing a closing paren, master reports 8 errors and parses no declaration beyond it; this branch reports 1 and parses the rest of the file.
  `expect()` consumed the token it had just rejected, usually the `fn` the parser needed to resynchronise on, and `parse_error_decl()` skipped a single token, so the top-level loop walked straight back into the same error. `expect()` now leaves the token in place, and `skip_to_decl()` runs on to the next declaration boundary, counting braces as it goes.
  
Other improvment:
- no unused-parameter warning for function prototypes, which have no body to use them in

Note:
- I cherry picked these changes from the language server artic fork. The fork still has more changes (mostly guarded by preprocessor macros) but these are mostly just relevant to language server integration. You could consider integrating them in the future if we want to improve maintenance of the language server