### PR TITLE
Print locations as file:row:col

### DIFF
--- a/include/artic/loc.h
+++ b/include/artic/loc.h
@@ -59,13 +59,12 @@ struct Loc {
 };
 
 inline std::ostream& operator << (std::ostream& os, const Loc& loc) {
-    os << *loc.file << "(";
-    os << loc.begin.row << ", " << loc.begin.col;
+    os << *loc.file << ":";
+    os << loc.begin.row << ":" << loc.begin.col;
     if (loc.begin.row != loc.end.row ||
         loc.begin.col != loc.end.col) {
-        os << " - " << loc.end.row << ", " << loc.end.col;
+        os << "-" << loc.end.row << ":" << loc.end.col;
     }
-    os << ")";
     return os;
 }
 


### PR DESCRIPTION
The current `file(row, col)` is not a format any editor or terminal recognises. `file:row:col` is what gcc, clang and rustc emit, so the location in an artic error message becomes clickable and greppable.